### PR TITLE
add support config TLS connection

### DIFF
--- a/client.go
+++ b/client.go
@@ -38,7 +38,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	}
 
 	if len(o.brokerAddress) == 0 && o.resolver == nil {
-		return nil, fmt.Errorf("at least WithTCPAddress or WithResolver ClientOption should be used")
+		return nil, fmt.Errorf("at least WithAddress or WithResolver ClientOption should be used")
 	}
 
 	c := &Client{options: o}
@@ -132,9 +132,10 @@ func toClientOptions(c *Client, o *clientOptions) *mqtt.ClientOptions {
 		opts.SetClientID(o.clientID)
 	}
 
-	opts.AddBroker(o.brokerAddress).
+	opts.AddBroker(formatAddressWithProtocol(o)).
 		SetUsername(o.username).
 		SetPassword(o.password).
+		SetTLSConfig(o.tlsConfig).
 		SetAutoReconnect(o.autoReconnect).
 		SetCleanSession(o.cleanSession).
 		SetOrderMatters(o.maintainOrder).
@@ -146,6 +147,14 @@ func toClientOptions(c *Client, o *clientOptions) *mqtt.ClientOptions {
 		SetOnConnectHandler(onConnectHandler(c, o))
 
 	return opts
+}
+
+func formatAddressWithProtocol(opts *clientOptions) string {
+	if opts.tlsConfig != nil {
+		return fmt.Sprintf("tls://%s", opts.brokerAddress)
+	}
+
+	return fmt.Sprintf("tcp://%s", opts.brokerAddress)
 }
 
 func reconnectHandler(client PubSub, o *clientOptions) mqtt.ReconnectHandler {

--- a/client_options_test.go
+++ b/client_options_test.go
@@ -1,6 +1,7 @@
 package courier
 
 import (
+	"crypto/tls"
 	"fmt"
 	"testing"
 	"time"
@@ -58,7 +59,12 @@ func (s *ClientOptionSuite) Test_apply() {
 		{
 			name:   "WithTCPAddress",
 			option: WithTCPAddress("localhost", 9999),
-			want:   &clientOptions{brokerAddress: fmt.Sprintf("tcp://%s:%d", "localhost", 9999)},
+			want:   &clientOptions{brokerAddress: fmt.Sprintf("%s:%d", "localhost", 9999)},
+		},
+		{
+			name:   "WithAddress",
+			option: WithAddress("localhost", 9999),
+			want:   &clientOptions{brokerAddress: fmt.Sprintf("%s:%d", "localhost", 9999)},
 		},
 		{
 			name:   "WithKeepAlive",
@@ -110,6 +116,13 @@ func (s *ClientOptionSuite) Test_function_based_apply() {
 	emptyErrFunc := func(error) {}
 	clientFunc := func(_ PubSub) {}
 
+	tlsConfig := &tls.Config{
+		RootCAs:      nil,
+		ClientAuth:   tls.NoClientCert,
+		ClientCAs:    nil,
+		Certificates: nil,
+	}
+
 	tests := []struct {
 		name   string
 		option ClientOption
@@ -144,6 +157,11 @@ func (s *ClientOptionSuite) Test_function_based_apply() {
 			name:   "WithUseBase64Decoder",
 			option: WithUseBase64Decoder(),
 			want:   &clientOptions{newDecoder: base64JsonDecoder},
+		},
+		{
+			name:   "WithTLS",
+			option: WithTLS(tlsConfig),
+			want:   &clientOptions{tlsConfig: tlsConfig},
 		},
 	}
 

--- a/client_resolver.go
+++ b/client_resolver.go
@@ -52,7 +52,7 @@ func (c *Client) attemptConnection(addrs []TCPAddress) {
 func (c *Client) newClient(addrs []TCPAddress, attempt int) mqtt.Client {
 	addr := addrs[attempt%len(addrs)]
 
-	c.options.brokerAddress = fmt.Sprintf("tcp://%s:%d", addr.Host, addr.Port)
+	c.options.brokerAddress = fmt.Sprintf("%s:%d", addr.Host, addr.Port)
 	cc := newClientFunc.Load().(func(*mqtt.ClientOptions) mqtt.Client)(toClientOptions(c, c.options))
 
 	t := cc.Connect()

--- a/client_test.go
+++ b/client_test.go
@@ -26,7 +26,7 @@ func init() {
 	list := strings.Split(brokerAddress, ":")
 	p, _ := strconv.Atoi(list[1])
 
-	defOpts = append(defOpts, WithTCPAddress(list[0], uint16(p)), WithClientID("clientID"))
+	defOpts = append(defOpts, WithAddress(list[0], uint16(p)), WithClientID("clientID"))
 }
 
 type ClientSuite struct {
@@ -97,7 +97,7 @@ func (s *ClientSuite) TestStart() {
 		},
 		{
 			name: "ConnectError",
-			opts: []ClientOption{WithTCPAddress("127.0.0.1", 9999), WithOnReconnect(func(_ PubSub) {
+			opts: []ClientOption{WithAddress("127.0.0.1", 9999), WithOnReconnect(func(_ PubSub) {
 				s.T().Logf("reconnecting")
 			})},
 			ctxFunc: func() (context.Context, context.CancelFunc) {
@@ -193,10 +193,10 @@ func TestNewClientWithResolverOption(t *testing.T) {
 
 func TestNewClient(t *testing.T) {
 	cc, err := NewClient()
-	assert.EqualError(t, err, "at least WithTCPAddress or WithResolver ClientOption should be used")
+	assert.EqualError(t, err, "at least WithAddress or WithResolver ClientOption should be used")
 	assert.Nil(t, cc)
 
-	cc, err = NewClient(WithTCPAddress("localhost", 1883))
+	cc, err = NewClient(WithAddress("localhost", 1883))
 	assert.NoError(t, err)
 	assert.NotNil(t, cc.mqttClient)
 }

--- a/docs/docs/Tutorials/connect.md
+++ b/docs/docs/Tutorials/connect.md
@@ -9,7 +9,7 @@ You can verify the connection by calling `.IsConnected()` and it should return t
 
 ```go title="connect.go" {2,11,15}
 c, err := courier.NewClient(
-    courier.WithTCPAddress("broker.emqx.io", 1883),
+    courier.WithAddress("broker.emqx.io", 1883),
     // courier.WithUsername("username"),
     // courier.WithPassword("password"),
 )

--- a/docs/docs/Tutorials/connect_background.md
+++ b/docs/docs/Tutorials/connect_background.md
@@ -11,7 +11,7 @@ You can wait for the connection with `courier.WaitForConnection` and verify the 
 
 ```go title="background_connect.go" {2,13,15}
 c, err := courier.NewClient(
-    courier.WithTCPAddress("broker.emqx.io", 1883),
+    courier.WithAddress("broker.emqx.io", 1883),
     // courier.WithUsername("username"),
     // courier.WithPassword("password"),
 )

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -45,7 +45,7 @@ func main() {
 	c, err := courier.NewClient(
 		courier.WithUsername("username"),
 		courier.WithPassword("password"),
-		courier.WithTCPAddress("localhost", 1883),
+		courier.WithAddress("localhost", 1883),
 	)
 
 	if err != nil {

--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -43,7 +43,7 @@ Package courier contains the client that can be used to interact with the courie
   - [func WithPassword(password string) ClientOption](<#func-withpassword>)
   - [func WithPersistence(store Store) ClientOption](<#func-withpersistence>)
   - [func WithResolver(resolver Resolver) ClientOption](<#func-withresolver>)
-  - [func WithTCPAddress(host string, port uint16) ClientOption](<#func-withtcpaddress>)
+  - [func WithAddress(host string, port uint16) ClientOption](<#func-withaddress>)
   - [func WithUseBase64Decoder() ClientOption](<#func-withusebase64decoder>)
   - [func WithUsername(username string) ClientOption](<#func-withusername>)
   - [func WithWriteTimeout(duration time.Duration) ClientOption](<#func-withwritetimeout>)
@@ -156,7 +156,7 @@ NewClient creates the Client struct with the clientOptions provided\, it can ret
 	c, err := courier.NewClient(
 		courier.WithUsername("username"),
 		courier.WithPassword("password"),
-		courier.WithTCPAddress("localhost", 1883),
+		courier.WithAddress("localhost", 1883),
 	)
 
 	if err != nil {
@@ -414,13 +414,13 @@ func WithResolver(resolver Resolver) ClientOption
 
 WithResolver sets the specified Resolver\.
 
-### func [WithTCPAddress](<https://github.com/gojek/courier-go/blob/main/client_options.go#L95>)
+### func [WithAddress](<https://github.com/gojek/courier-go/blob/main/client_options.go#L95>)
 
 ```go
-func WithTCPAddress(host string, port uint16) ClientOption
+func WithAddress(host string, port uint16) ClientOption
 ```
 
-WithTCPAddress sets the broker address to be used\. Default values for hostname is "127\.0\.0\.1" and for port is 1883\.
+WithAddress sets the broker address to be used\. Default values for hostname is "127\.0\.0\.1" and for port is 1883\ the protocol << tcp ot tls >> is set off depend on option  `WithTLS`,if this one is nil then the protocol is `tcp`.
 
 ### func [WithUseBase64Decoder](<https://github.com/gojek/courier-go/blob/main/client_options.go#L166>)
 

--- a/example_test.go
+++ b/example_test.go
@@ -15,7 +15,7 @@ func ExampleNewClient() {
 	c, err := courier.NewClient(
 		courier.WithUsername("username"),
 		courier.WithPassword("password"),
-		courier.WithTCPAddress("localhost", 1883),
+		courier.WithAddress("localhost", 1883),
 	)
 
 	if err != nil {

--- a/otelcourier/trace_test.go
+++ b/otelcourier/trace_test.go
@@ -56,7 +56,7 @@ func TestInstrumentClient(t *testing.T) {
 	tp.RegisterSpanProcessor(sr)
 
 	tr := NewTracer("test-service", WithTracerProvider(tp))
-	c, err := courier.NewClient(courier.WithTCPAddress("localhost", 1883))
+	c, err := courier.NewClient(courier.WithAddress("localhost", 1883))
 	assert.NoError(t, err)
 	tr.ApplyTraceMiddlewares(c)
 }


### PR DESCRIPTION
Hi guys 

I added a client option called  `WithTLS` where it's possible to add configuration in order to get a `TLS` connection with the MQTT broker, also I changed the method `WithTCPAddress` to `WithAddress` such the communication now can be TLS too