### PR TITLE
add context to EncoderFunc/DecoderFunc signature

### DIFF
--- a/client_options.go
+++ b/client_options.go
@@ -215,8 +215,8 @@ func defaultClientOptions() *clientOptions {
 		maxReconnectInterval:   5 * time.Minute,
 		gracefulShutdownPeriod: 30 * time.Second,
 		keepAlive:              60 * time.Second,
-		newEncoder:             defaultEncoderFunc,
-		newDecoder:             defaultDecoderFunc,
+		newEncoder:             DefaultEncoderFunc,
+		newDecoder:             DefaultDecoderFunc,
 		store:                  inMemoryPersistence,
 	}
 }

--- a/client_options_test.go
+++ b/client_options_test.go
@@ -150,8 +150,8 @@ func (s *ClientOptionSuite) Test_function_based_apply() {
 		},
 		{
 			name:   "WithCustomEncoder",
-			option: WithCustomEncoder(defaultEncoderFunc),
-			want:   &clientOptions{newEncoder: defaultEncoderFunc},
+			option: WithCustomEncoder(DefaultEncoderFunc),
+			want:   &clientOptions{newEncoder: DefaultEncoderFunc},
 		},
 		{
 			name:   "WithUseBase64Decoder",
@@ -187,8 +187,8 @@ func (s *ClientOptionSuite) Test_defaultOptions() {
 		maxReconnectInterval:   5 * time.Minute,
 		gracefulShutdownPeriod: 30 * time.Second,
 		keepAlive:              60 * time.Second,
-		newEncoder:             defaultEncoderFunc,
-		newDecoder:             defaultDecoderFunc,
+		newEncoder:             DefaultEncoderFunc,
+		newDecoder:             DefaultDecoderFunc,
 		store:                  inMemoryPersistence,
 	}
 

--- a/client_publish.go
+++ b/client_publish.go
@@ -31,7 +31,7 @@ func publishHandler(c *Client) Publisher {
 	return PublisherFunc(func(ctx context.Context, topic string, message interface{}, opts ...Option) (err error) {
 		buf := bytes.Buffer{}
 
-		err = c.options.newEncoder(&buf).Encode(message)
+		err = c.options.newEncoder(ctx, &buf).Encode(message)
 		if err != nil {
 			return
 		}

--- a/client_publish_test.go
+++ b/client_publish_test.go
@@ -35,7 +35,7 @@ func (s *ClientPublishSuite) TestPublish() {
 				t.On("WaitTimeout", 10*time.Second).Return(true)
 				t.On("Error").Return(nil)
 				buf := bytes.Buffer{}
-				_ = defaultEncoderFunc(&buf).Encode(p)
+				_ = DefaultEncoderFunc(context.TODO(), &buf).Encode(p)
 				m.On("Publish", "topic", byte(QOSOne), false, buf.Bytes()).Return(t)
 				return t
 			},
@@ -48,7 +48,7 @@ func (s *ClientPublishSuite) TestPublish() {
 				t.On("WaitTimeout", 10*time.Second).Return(true)
 				t.On("Error").Return(nil)
 				buf := bytes.Buffer{}
-				_ = defaultEncoderFunc(&buf).Encode(p)
+				_ = DefaultEncoderFunc(context.TODO(), &buf).Encode(p)
 				m.On("Publish", "topic-new", byte(QOSOne), false, buf.Bytes()).Return(t)
 				return t
 			},
@@ -82,7 +82,7 @@ func (s *ClientPublishSuite) TestPublish() {
 				t := &mockToken{}
 				t.On("WaitTimeout", 10*time.Second).Return(false)
 				buf := bytes.Buffer{}
-				_ = defaultEncoderFunc(&buf).Encode(p)
+				_ = DefaultEncoderFunc(context.TODO(), &buf).Encode(p)
 				m.On("Publish", "topic", byte(QOSOne), false, buf.Bytes()).Return(t)
 				return t
 			},
@@ -96,7 +96,7 @@ func (s *ClientPublishSuite) TestPublish() {
 				t.On("WaitTimeout", 10*time.Second).Return(true)
 				t.On("Error").Return(errors.New("random_error"))
 				buf := bytes.Buffer{}
-				_ = defaultEncoderFunc(&buf).Encode(p)
+				_ = DefaultEncoderFunc(context.TODO(), &buf).Encode(p)
 				m.On("Publish", "topic", byte(QOSOne), false, buf.Bytes()).Return(t)
 				return t
 			},
@@ -112,6 +112,7 @@ func (s *ClientPublishSuite) TestPublish() {
 			wantErr: true,
 		},
 	}
+
 	for _, t := range tests {
 		s.Run(t.name, func() {
 			c, err := NewClient(defOpts...)

--- a/client_subscribe.go
+++ b/client_subscribe.go
@@ -60,8 +60,10 @@ func subscriberFuncs(c *Client) Subscriber {
 
 func callbackWrapper(c *Client, callback MessageHandler) mqtt.MessageHandler {
 	return func(_ mqtt.Client, m mqtt.Message) {
+		ctx := context.Background()
+
 		msg := NewMessageWithDecoder(
-			c.options.newDecoder(bytes.NewReader(m.Payload())),
+			c.options.newDecoder(ctx, bytes.NewReader(m.Payload())),
 		)
 		msg.ID = int(m.MessageID())
 		msg.Topic = m.Topic()
@@ -69,7 +71,7 @@ func callbackWrapper(c *Client, callback MessageHandler) mqtt.MessageHandler {
 		msg.Retained = m.Retained()
 		msg.QoS = QOSLevel(m.Qos())
 
-		callback(context.Background(), c, msg)
+		callback(ctx, c, msg)
 	}
 }
 

--- a/decoder.go
+++ b/decoder.go
@@ -1,6 +1,7 @@
 package courier
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"io"
@@ -8,7 +9,7 @@ import (
 
 // DecoderFunc is used to create a Decoder from io.Reader stream
 // of message bytes before calling MessageHandler
-type DecoderFunc func(io.Reader) Decoder
+type DecoderFunc func(context.Context, io.Reader) Decoder
 
 // Decoder helps to decode message bytes into the desired object
 type Decoder interface {
@@ -16,11 +17,12 @@ type Decoder interface {
 	Decode(v interface{}) error
 }
 
-func defaultDecoderFunc(r io.Reader) Decoder {
+// DefaultDecoderFunc is a DecoderFunc that uses a json.Decoder as the Decoder.
+func DefaultDecoderFunc(_ context.Context, r io.Reader) Decoder {
 	return json.NewDecoder(r)
 }
 
-func base64JsonDecoder(r io.Reader) Decoder {
+func base64JsonDecoder(_ context.Context, r io.Reader) Decoder {
 	return json.NewDecoder(base64.NewDecoder(base64.StdEncoding, r))
 }
 

--- a/decoder.go
+++ b/decoder.go
@@ -8,7 +8,8 @@ import (
 )
 
 // DecoderFunc is used to create a Decoder from io.Reader stream
-// of message bytes before calling MessageHandler
+// of message bytes before calling MessageHandler;
+// the context.Context value may be used to select appropriate Decoder.
 type DecoderFunc func(context.Context, io.Reader) Decoder
 
 // Decoder helps to decode message bytes into the desired object

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1,6 +1,7 @@
 package courier
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -41,7 +42,7 @@ func (s *jsonDecoderSuite) TestDecode() {
 	}
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			d := defaultDecoderFunc(strings.NewReader(tt.payload))
+			d := DefaultDecoderFunc(context.TODO(), strings.NewReader(tt.payload))
 
 			err := d.Decode(&tt.result)
 
@@ -74,7 +75,7 @@ func (s *jsonDecoderSuite) TestDecodeWithBase64() {
 	}
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			d := base64JsonDecoder(strings.NewReader(tt.payload))
+			d := base64JsonDecoder(context.TODO(), strings.NewReader(tt.payload))
 
 			err := d.Decode(&tt.result)
 

--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -51,8 +51,10 @@ Package courier contains the client that can be used to interact with the courie
   - [func WithWriteTimeout(duration time.Duration) ClientOption](<#func-withwritetimeout>)
 - [type ConnectionInformer](<#type-connectioninformer>)
 - [type Decoder](<#type-decoder>)
+  - [func DefaultDecoderFunc(_ context.Context, r io.Reader) Decoder](<#func-defaultdecoderfunc>)
 - [type DecoderFunc](<#type-decoderfunc>)
 - [type Encoder](<#type-encoder>)
+  - [func DefaultEncoderFunc(_ context.Context, w io.Writer) Encoder](<#func-defaultencoderfunc>)
 - [type EncoderFunc](<#type-encoderfunc>)
 - [type Message](<#type-message>)
   - [func NewMessageWithDecoder(payloadDecoder Decoder) *Message](<#func-newmessagewithdecoder>)
@@ -479,7 +481,7 @@ type ConnectionInformer interface {
 }
 ```
 
-## type [Decoder](<https://github.com/gojek/courier-go/blob/main/decoder.go#L14-L17>)
+## type [Decoder](<https://github.com/gojek/courier-go/blob/main/decoder.go#L15-L18>)
 
 Decoder helps to decode message bytes into the desired object
 
@@ -490,15 +492,23 @@ type Decoder interface {
 }
 ```
 
-## type [DecoderFunc](<https://github.com/gojek/courier-go/blob/main/decoder.go#L11>)
+### func [DefaultDecoderFunc](<https://github.com/gojek/courier-go/blob/main/decoder.go#L21>)
+
+```go
+func DefaultDecoderFunc(_ context.Context, r io.Reader) Decoder
+```
+
+DefaultDecoderFunc is a DecoderFunc that uses a json.Decoder as the Decoder.
+
+## type [DecoderFunc](<https://github.com/gojek/courier-go/blob/main/decoder.go#L12>)
 
 DecoderFunc is used to create a Decoder from io.Reader stream of message bytes before calling MessageHandler
 
 ```go
-type DecoderFunc func(io.Reader) Decoder
+type DecoderFunc func(context.Context, io.Reader) Decoder
 ```
 
-## type [Encoder](<https://github.com/gojek/courier-go/blob/main/encoder.go#L12-L15>)
+## type [Encoder](<https://github.com/gojek/courier-go/blob/main/encoder.go#L13-L16>)
 
 Encoder helps in transforming objects to message bytes
 
@@ -509,12 +519,20 @@ type Encoder interface {
 }
 ```
 
-## type [EncoderFunc](<https://github.com/gojek/courier-go/blob/main/encoder.go#L9>)
+### func [DefaultEncoderFunc](<https://github.com/gojek/courier-go/blob/main/encoder.go#L19>)
+
+```go
+func DefaultEncoderFunc(_ context.Context, w io.Writer) Encoder
+```
+
+DefaultEncoderFunc is a EncoderFunc that uses a json.Encoder as the Encoder.
+
+## type [EncoderFunc](<https://github.com/gojek/courier-go/blob/main/encoder.go#L10>)
 
 EncoderFunc is used to create an Encoder from io.Writer
 
 ```go
-type EncoderFunc func(io.Writer) Encoder
+type EncoderFunc func(context.Context, io.Writer) Encoder
 ```
 
 ## type [Message](<https://github.com/gojek/courier-go/blob/main/message.go#L4-L12>)

--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -481,7 +481,7 @@ type ConnectionInformer interface {
 }
 ```
 
-## type [Decoder](<https://github.com/gojek/courier-go/blob/main/decoder.go#L15-L18>)
+## type [Decoder](<https://github.com/gojek/courier-go/blob/main/decoder.go#L16-L19>)
 
 Decoder helps to decode message bytes into the desired object
 
@@ -492,7 +492,7 @@ type Decoder interface {
 }
 ```
 
-### func [DefaultDecoderFunc](<https://github.com/gojek/courier-go/blob/main/decoder.go#L21>)
+### func [DefaultDecoderFunc](<https://github.com/gojek/courier-go/blob/main/decoder.go#L22>)
 
 ```go
 func DefaultDecoderFunc(_ context.Context, r io.Reader) Decoder
@@ -500,15 +500,15 @@ func DefaultDecoderFunc(_ context.Context, r io.Reader) Decoder
 
 DefaultDecoderFunc is a DecoderFunc that uses a json.Decoder as the Decoder.
 
-## type [DecoderFunc](<https://github.com/gojek/courier-go/blob/main/decoder.go#L12>)
+## type [DecoderFunc](<https://github.com/gojek/courier-go/blob/main/decoder.go#L13>)
 
-DecoderFunc is used to create a Decoder from io.Reader stream of message bytes before calling MessageHandler
+DecoderFunc is used to create a Decoder from io.Reader stream of message bytes before calling MessageHandler; the context.Context value may be used to select appropriate Decoder.
 
 ```go
 type DecoderFunc func(context.Context, io.Reader) Decoder
 ```
 
-## type [Encoder](<https://github.com/gojek/courier-go/blob/main/encoder.go#L13-L16>)
+## type [Encoder](<https://github.com/gojek/courier-go/blob/main/encoder.go#L14-L17>)
 
 Encoder helps in transforming objects to message bytes
 
@@ -519,7 +519,7 @@ type Encoder interface {
 }
 ```
 
-### func [DefaultEncoderFunc](<https://github.com/gojek/courier-go/blob/main/encoder.go#L19>)
+### func [DefaultEncoderFunc](<https://github.com/gojek/courier-go/blob/main/encoder.go#L20>)
 
 ```go
 func DefaultEncoderFunc(_ context.Context, w io.Writer) Encoder
@@ -527,9 +527,9 @@ func DefaultEncoderFunc(_ context.Context, w io.Writer) Encoder
 
 DefaultEncoderFunc is a EncoderFunc that uses a json.Encoder as the Encoder.
 
-## type [EncoderFunc](<https://github.com/gojek/courier-go/blob/main/encoder.go#L10>)
+## type [EncoderFunc](<https://github.com/gojek/courier-go/blob/main/encoder.go#L11>)
 
-EncoderFunc is used to create an Encoder from io.Writer
+EncoderFunc is used to create an Encoder from io.Writer; the context.Context value may be used to select appropriate Encoder.
 
 ```go
 type EncoderFunc func(context.Context, io.Writer) Encoder

--- a/encoder.go
+++ b/encoder.go
@@ -6,7 +6,8 @@ import (
 	"io"
 )
 
-// EncoderFunc is used to create an Encoder from io.Writer
+// EncoderFunc is used to create an Encoder from io.Writer;
+// the context.Context value may be used to select appropriate Encoder.
 type EncoderFunc func(context.Context, io.Writer) Encoder
 
 // Encoder helps in transforming objects to message bytes

--- a/encoder.go
+++ b/encoder.go
@@ -1,12 +1,13 @@
 package courier
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 )
 
 // EncoderFunc is used to create an Encoder from io.Writer
-type EncoderFunc func(io.Writer) Encoder
+type EncoderFunc func(context.Context, io.Writer) Encoder
 
 // Encoder helps in transforming objects to message bytes
 type Encoder interface {
@@ -14,7 +15,8 @@ type Encoder interface {
 	Encode(v interface{}) error
 }
 
-func defaultEncoderFunc(w io.Writer) Encoder {
+// DefaultEncoderFunc is a EncoderFunc that uses a json.Encoder as the Encoder.
+func DefaultEncoderFunc(_ context.Context, w io.Writer) Encoder {
 	return json.NewEncoder(w)
 }
 

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -2,6 +2,7 @@ package courier
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"math"
 	"testing"
@@ -45,7 +46,7 @@ func Test_defaultEncoderFunc(t *testing.T) {
 			wantBuf, wantErr := tt.want()
 
 			buf := bytes.Buffer{}
-			j := defaultEncoderFunc(&buf)
+			j := DefaultEncoderFunc(context.TODO(), &buf)
 			err := j.Encode(tt.obj)
 
 			if wantErr != nil {


### PR DESCRIPTION
Add context.Context as first argument to EncoderFunc/DecoderFunc, this context may be used to select the appropriate Encoder/Decoder.