### PR TITLE
Handle token context

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,13 +25,15 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
         uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - name: Go mod cache
+        uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - uses: actions/cache@v2
+      - name: Tools bin cache
+        uses: actions/cache@v2
         with:
           path: .bin
           key: ${{ runner.os }}-${{ hashFiles('Makefile') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,10 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+      - uses: actions/cache@v2
+        with:
+          path: .bin
+          key: ${{ runner.os }}-${{ hashFiles('Makefile') }}
       - name: Install jq
         run: apt update && apt -y install jq
       - name: Test

--- a/client.go
+++ b/client.go
@@ -111,8 +111,10 @@ func (c *Client) Run(ctx context.Context) error {
 	if err := c.Start(); err != nil {
 		return err
 	}
+
 	<-ctx.Done()
 	c.Stop()
+
 	return nil
 }
 

--- a/client.go
+++ b/client.go
@@ -55,13 +55,6 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	return c, nil
 }
 
-func (c *Client) execute(f func(mqtt.Client)) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	f(c.mqttClient)
-}
-
 // IsConnected checks whether the client is connected to the broker
 func (c *Client) IsConnected() (online bool) {
 	c.execute(func(cc mqtt.Client) {
@@ -121,6 +114,13 @@ func (c *Client) Run(ctx context.Context) error {
 	<-ctx.Done()
 	c.Stop()
 	return nil
+}
+
+func (c *Client) execute(f func(mqtt.Client)) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	f(c.mqttClient)
 }
 
 func (c *Client) handleToken(ctx context.Context, t mqtt.Token, timeoutErr error) error {

--- a/client.go
+++ b/client.go
@@ -112,6 +112,17 @@ func (c *Client) Stop() {
 	})
 }
 
+// Run will start running the Client. This makes Client compatible with github.com/gojekfarm/xrun package.
+// https://pkg.go.dev/github.com/gojekfarm/xrun
+func (c *Client) Run(ctx context.Context) error {
+	if err := c.Start(); err != nil {
+		return err
+	}
+	<-ctx.Done()
+	c.Stop()
+	return nil
+}
+
 func (c *Client) handleToken(ctx context.Context, t mqtt.Token, timeoutErr error) error {
 	if err := c.waitForToken(ctx, t, timeoutErr); err != nil {
 		return err

--- a/client_options.go
+++ b/client_options.go
@@ -137,7 +137,9 @@ func WithConnectTimeout(duration time.Duration) ClientOption {
 	})
 }
 
-// WithWriteTimeout limits how long the client will wait when trying to publish or subscribe on topic.
+// WithWriteTimeout limits how long the client will wait when trying to publish, subscribe or unsubscribe on topic
+// when a context deadline is not set while calling Publisher.Publish, Subscriber.Subscribe,
+// Subscriber.SubscribeMultiple or Unsubscriber.Unsubscribe.
 func WithWriteTimeout(duration time.Duration) ClientOption {
 	return optionFunc(func(o *clientOptions) {
 		o.writeTimeout = duration

--- a/client_publish.go
+++ b/client_publish.go
@@ -39,7 +39,7 @@ func publishHandler(c *Client) Publisher {
 		o := composeOptions(opts)
 		c.execute(func(cc mqtt.Client) {
 			t := cc.Publish(topic, o.qos, o.retained, buf.Bytes())
-			err = c.handleToken(t, ErrPublishTimeout)
+			err = c.handleToken(ctx, t, ErrPublishTimeout)
 		})
 
 		return

--- a/client_subscribe.go
+++ b/client_subscribe.go
@@ -42,7 +42,7 @@ func subscriberFuncs(c *Client) Subscriber {
 			o := composeOptions(opts)
 			c.execute(func(cc mqtt.Client) {
 				t := cc.Subscribe(topic, o.qos, callbackWrapper(c, callback))
-				err = c.handleToken(t, ErrSubscribeTimeout)
+				err = c.handleToken(ctx, t, ErrSubscribeTimeout)
 			})
 
 			return
@@ -50,7 +50,7 @@ func subscriberFuncs(c *Client) Subscriber {
 		func(ctx context.Context, topicsWithQos map[string]QOSLevel, callback MessageHandler) (err error) {
 			c.execute(func(cc mqtt.Client) {
 				t := cc.SubscribeMultiple(routeFilters(topicsWithQos), callbackWrapper(c, callback))
-				err = c.handleToken(t, ErrSubscribeMultipleTimeout)
+				err = c.handleToken(ctx, t, ErrSubscribeMultipleTimeout)
 			})
 
 			return

--- a/client_unsubscribe.go
+++ b/client_unsubscribe.go
@@ -30,7 +30,7 @@ func unsubscriberHandler(c *Client) Unsubscriber {
 	return UnsubscriberFunc(func(ctx context.Context, topics ...string) (err error) {
 		c.execute(func(cc mqtt.Client) {
 			t := cc.Unsubscribe(topics...)
-			err = c.handleToken(t, ErrUnsubscribeTimeout)
+			err = c.handleToken(ctx, t, ErrUnsubscribeTimeout)
 		})
 
 		return

--- a/client_unsubscribe_test.go
+++ b/client_unsubscribe_test.go
@@ -22,6 +22,7 @@ func (s *ClientUnsubscribeSuite) TestUnsubscribe() {
 	topics := []string{"topic1", "topic2"}
 	testcases := []struct {
 		name           string
+		ctxFn          func() (context.Context, context.CancelFunc)
 		pahoMock       func(*mock.Mock) *mockToken
 		wantErr        bool
 		useMiddlewares []UnsubscriberMiddlewareFunc
@@ -64,12 +65,51 @@ func (s *ClientUnsubscribeSuite) TestUnsubscribe() {
 			},
 		},
 		{
-			name: "WaitTimeout",
+			name: "DefaultWaitTimeout",
 			pahoMock: func(m *mock.Mock) *mockToken {
 				t := &mockToken{}
 				t.On("WaitTimeout", 10*time.Second).Return(false)
 				m.On("Unsubscribe", topics).
 					Return(t)
+				return t
+			},
+			wantErr: true,
+		},
+		{
+			name: "ContextDeadline",
+			ctxFn: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(context.Background(), time.Second)
+			},
+			pahoMock: func(m *mock.Mock) *mockToken {
+				ch := make(<-chan struct{})
+				t := &mockToken{}
+				t.On("Done").Return(ch)
+
+				m.On("Unsubscribe", topics).Return(t)
+
+				return t
+			},
+			wantErr: true,
+		},
+		{
+			name: "TokenError",
+			ctxFn: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(context.Background(), 10*time.Second)
+			},
+			pahoMock: func(m *mock.Mock) *mockToken {
+				ch := make(chan struct{})
+
+				go func() {
+					<-time.After(2 * time.Second)
+					ch <- struct{}{}
+				}()
+
+				t := &mockToken{}
+				t.On("Done").Return(readOnlyChannel(ch))
+				t.On("Error").Return(errors.New("token timed out"))
+
+				m.On("Unsubscribe", topics).Return(t)
+
 				return t
 			},
 			wantErr: true,
@@ -100,7 +140,14 @@ func (s *ClientUnsubscribeSuite) TestUnsubscribe() {
 			c.mqttClient = mc
 			tk := t.pahoMock(&mc.Mock)
 
-			err = c.Unsubscribe(context.Background(), topics...)
+			ctx := context.Background()
+			if t.ctxFn != nil {
+				_ctx, cancel := t.ctxFn()
+				ctx = _ctx
+				defer cancel()
+			}
+
+			err = c.Unsubscribe(ctx, topics...)
 
 			if !t.wantErr {
 				s.NoError(err)

--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -18,6 +18,7 @@ Package courier contains the client that can be used to interact with the courie
   - [func NewClient(opts ...ClientOption) (*Client, error)](<#func-newclient>)
   - [func (c *Client) IsConnected() (online bool)](<#func-client-isconnected>)
   - [func (c *Client) Publish(ctx context.Context, topic string, message interface{}, opts ...Option) error](<#func-client-publish>)
+  - [func (c *Client) Run(ctx context.Context) error](<#func-client-run>)
   - [func (c *Client) Start() (err error)](<#func-client-start>)
   - [func (c *Client) Stop()](<#func-client-stop>)
   - [func (c *Client) Subscribe(ctx context.Context, topic string, callback MessageHandler, opts ...Option) error](<#func-client-subscribe>)
@@ -217,6 +218,14 @@ func (c *Client) Publish(ctx context.Context, topic string, message interface{},
 ```
 
 Publish allows to publish messages to an MQTT broker
+
+### func \(\*Client\) [Run](<https://github.com/gojek/courier-go/blob/main/client.go#L117>)
+
+```go
+func (c *Client) Run(ctx context.Context) error
+```
+
+Run will start running the Client. This makes Client compatible with github.com/gojekfarm/xrun package. https://pkg.go.dev/github.com/gojekfarm/xrun
 
 ### func \(\*Client\) [Start](<https://github.com/gojek/courier-go/blob/main/client.go#L75>)
 

--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -203,7 +203,7 @@ NewClient creates the Client struct with the clientOptions provided, it can retu
 </p>
 </details>
 
-### func \(\*Client\) [IsConnected](<https://github.com/gojek/courier-go/blob/main/client.go#L66>)
+### func \(\*Client\) [IsConnected](<https://github.com/gojek/courier-go/blob/main/client.go#L59>)
 
 ```go
 func (c *Client) IsConnected() (online bool)
@@ -219,7 +219,7 @@ func (c *Client) Publish(ctx context.Context, topic string, message interface{},
 
 Publish allows to publish messages to an MQTT broker
 
-### func \(\*Client\) [Run](<https://github.com/gojek/courier-go/blob/main/client.go#L117>)
+### func \(\*Client\) [Run](<https://github.com/gojek/courier-go/blob/main/client.go#L110>)
 
 ```go
 func (c *Client) Run(ctx context.Context) error
@@ -227,7 +227,7 @@ func (c *Client) Run(ctx context.Context) error
 
 Run will start running the Client. This makes Client compatible with github.com/gojekfarm/xrun package. https://pkg.go.dev/github.com/gojekfarm/xrun
 
-### func \(\*Client\) [Start](<https://github.com/gojek/courier-go/blob/main/client.go#L75>)
+### func \(\*Client\) [Start](<https://github.com/gojek/courier-go/blob/main/client.go#L68>)
 
 ```go
 func (c *Client) Start() (err error)
@@ -235,7 +235,7 @@ func (c *Client) Start() (err error)
 
 Start will attempt to connect to the broker.
 
-### func \(\*Client\) [Stop](<https://github.com/gojek/courier-go/blob/main/client.go#L109>)
+### func \(\*Client\) [Stop](<https://github.com/gojek/courier-go/blob/main/client.go#L102>)
 
 ```go
 func (c *Client) Stop()

--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -134,7 +134,7 @@ func WaitForConnection(c ConnectionInformer, waitFor time.Duration, tick time.Du
 
 WaitForConnection checks if the Client is connected, it calls ConnectionInformer.IsConnected after every tick and waitFor is the maximum duration it can block. Returns true only when ConnectionInformer.IsConnected returns true
 
-## type [Client](<https://github.com/gojek/courier-go/blob/main/client.go#L16-L28>)
+## type [Client](<https://github.com/gojek/courier-go/blob/main/client.go#L17-L29>)
 
 Client allows to communicate with an MQTT broker
 
@@ -144,7 +144,7 @@ type Client struct {
 }
 ```
 
-### func [NewClient](<https://github.com/gojek/courier-go/blob/main/client.go#L33>)
+### func [NewClient](<https://github.com/gojek/courier-go/blob/main/client.go#L34>)
 
 ```go
 func NewClient(opts ...ClientOption) (*Client, error)
@@ -202,7 +202,7 @@ NewClient creates the Client struct with the clientOptions provided, it can retu
 </p>
 </details>
 
-### func \(\*Client\) [IsConnected](<https://github.com/gojek/courier-go/blob/main/client.go#L65>)
+### func \(\*Client\) [IsConnected](<https://github.com/gojek/courier-go/blob/main/client.go#L66>)
 
 ```go
 func (c *Client) IsConnected() (online bool)
@@ -218,7 +218,7 @@ func (c *Client) Publish(ctx context.Context, topic string, message interface{},
 
 Publish allows to publish messages to an MQTT broker
 
-### func \(\*Client\) [Start](<https://github.com/gojek/courier-go/blob/main/client.go#L74>)
+### func \(\*Client\) [Start](<https://github.com/gojek/courier-go/blob/main/client.go#L75>)
 
 ```go
 func (c *Client) Start() (err error)
@@ -226,7 +226,7 @@ func (c *Client) Start() (err error)
 
 Start will attempt to connect to the broker.
 
-### func \(\*Client\) [Stop](<https://github.com/gojek/courier-go/blob/main/client.go#L108>)
+### func \(\*Client\) [Stop](<https://github.com/gojek/courier-go/blob/main/client.go#L109>)
 
 ```go
 func (c *Client) Stop()
@@ -332,7 +332,7 @@ func WithConnectTimeout(duration time.Duration) ClientOption
 
 WithConnectTimeout limits how long the client will wait when trying to open a connection to an MQTT server before timing out. A duration of 0 never times out. Default 15 seconds.
 
-### func [WithCustomDecoder](<https://github.com/gojek/courier-go/blob/main/client_options.go#L174>)
+### func [WithCustomDecoder](<https://github.com/gojek/courier-go/blob/main/client_options.go#L176>)
 
 ```go
 func WithCustomDecoder(decoderFunc DecoderFunc) ClientOption
@@ -340,7 +340,7 @@ func WithCustomDecoder(decoderFunc DecoderFunc) ClientOption
 
 WithCustomDecoder allows to decode message bytes into the desired object.
 
-### func [WithCustomEncoder](<https://github.com/gojek/courier-go/blob/main/client_options.go#L171>)
+### func [WithCustomEncoder](<https://github.com/gojek/courier-go/blob/main/client_options.go#L173>)
 
 ```go
 func WithCustomEncoder(encoderFunc EncoderFunc) ClientOption
@@ -348,7 +348,7 @@ func WithCustomEncoder(encoderFunc EncoderFunc) ClientOption
 
 WithCustomEncoder allows to transform objects into the desired message bytes.
 
-### func [WithGracefulShutdownPeriod](<https://github.com/gojek/courier-go/blob/main/client_options.go#L156>)
+### func [WithGracefulShutdownPeriod](<https://github.com/gojek/courier-go/blob/main/client_options.go#L158>)
 
 ```go
 func WithGracefulShutdownPeriod(duration time.Duration) ClientOption
@@ -372,7 +372,7 @@ func WithMaintainOrder(maintainOrder bool) ClientOption
 
 WithMaintainOrder will set the message routing to guarantee order within each QoS level. By default, this value is true. If set to false \(recommended\), this flag indicates that messages can be delivered asynchronously from the client to the application and possibly arrive out of order. Specifically, the message handler is called in its own go routine. Note that setting this to true does not guarantee in\-order delivery \(this is subject to broker settings like "max\_inflight\_messages=1"\) and if true then  MessageHandler callback must not block.
 
-### func [WithMaxReconnectInterval](<https://github.com/gojek/courier-go/blob/main/client_options.go#L149>)
+### func [WithMaxReconnectInterval](<https://github.com/gojek/courier-go/blob/main/client_options.go#L151>)
 
 ```go
 func WithMaxReconnectInterval(duration time.Duration) ClientOption
@@ -412,7 +412,7 @@ func WithPassword(password string) ClientOption
 
 WithPassword sets the password to be used while connecting to an MQTT broker.
 
-### func [WithPersistence](<https://github.com/gojek/courier-go/blob/main/client_options.go#L164>)
+### func [WithPersistence](<https://github.com/gojek/courier-go/blob/main/client_options.go#L166>)
 
 ```go
 func WithPersistence(store Store) ClientOption
@@ -446,7 +446,7 @@ func WithTLS(tlsConfig *tls.Config) ClientOption
 
 WithTLS sets the TLs configuration to be used while connecting to an MQTT broker.
 
-### func [WithUseBase64Decoder](<https://github.com/gojek/courier-go/blob/main/client_options.go#L178>)
+### func [WithUseBase64Decoder](<https://github.com/gojek/courier-go/blob/main/client_options.go#L180>)
 
 ```go
 func WithUseBase64Decoder() ClientOption
@@ -462,13 +462,13 @@ func WithUsername(username string) ClientOption
 
 WithUsername sets the username to be used while connecting to an MQTT broker.
 
-### func [WithWriteTimeout](<https://github.com/gojek/courier-go/blob/main/client_options.go#L141>)
+### func [WithWriteTimeout](<https://github.com/gojek/courier-go/blob/main/client_options.go#L143>)
 
 ```go
 func WithWriteTimeout(duration time.Duration) ClientOption
 ```
 
-WithWriteTimeout limits how long the client will wait when trying to publish or subscribe on topic.
+WithWriteTimeout limits how long the client will wait when trying to publish, subscribe or unsubscribe on topic when a context deadline is not set while calling Publisher.Publish, Subscriber.Subscribe, Subscriber.SubscribeMultiple or Unsubscriber.Unsubscribe.
 
 ## type [ConnectionInformer](<https://github.com/gojek/courier-go/blob/main/interface.go#L13-L16>)
 


### PR DESCRIPTION
Publish, Subscribe and Unsubscribe calls will now respect the Deadline passed in the context, if any. In case deadline is missing, it will fallback to write timeout.