### PR TITLE
add InfoHandler and ClientInfoEmitter for exposing connected clients information

### DIFF
--- a/client_options.go
+++ b/client_options.go
@@ -267,6 +267,7 @@ type clientOptions struct {
 	onReconnectHandler          OnReconnectHandler
 	sharedSubscriptionPredicate SharedSubscriptionPredicate
 	logger                      Logger
+	infoEmitterCfg              *ClientInfoEmitterConfig
 
 	newEncoder EncoderFunc
 	newDecoder DecoderFunc

--- a/client_publish_test.go
+++ b/client_publish_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math"
 	"sync"
 	"testing"
@@ -260,7 +261,7 @@ func (s *ClientPublishSuite) TestPublishWithMultiConnectionMode() {
 		tba := testBrokerAddress
 		tba.Port = uint16(1883 + i)
 
-		clients[tba.String()] = mc
+		clients[fmt.Sprintf("%s-%d", tba.String(), ii)] = mc
 
 		mcks = append(mcks, mc, mt)
 	}

--- a/client_resolver.go
+++ b/client_resolver.go
@@ -19,8 +19,8 @@ import (
 
 // TCPAddress specifies Host and Port for remote broker
 type TCPAddress struct {
-	Host string
-	Port uint16
+	Host string `json:"host"`
+	Port uint16 `json:"port"`
 }
 
 func (t TCPAddress) String() string { return fmt.Sprintf("%s:%d", t.Host, t.Port) }

--- a/client_telemetry.go
+++ b/client_telemetry.go
@@ -1,0 +1,89 @@
+package courier
+
+import (
+	"net/url"
+	"sort"
+	"strconv"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+
+	"github.com/gojekfarm/xtools/generic/slice"
+)
+
+// MQTTClientInfo contains information about the internal MQTT client
+type MQTTClientInfo struct {
+	Addresses     []TCPAddress `json:"addresses"`
+	ClientID      string       `json:"client_id"`
+	Username      string       `json:"username"`
+	ResumeSubs    bool         `json:"resume_subs"`
+	CleanSession  bool         `json:"clean_session"`
+	AutoReconnect bool         `json:"auto_reconnect"`
+	Connected     bool         `json:"connected"`
+}
+
+type clientIntoList []MQTTClientInfo
+
+func (c *Client) allClientInfo() clientIntoList {
+	if c.options.multiConnectionMode {
+		return c.multiClientInfo()
+	}
+
+	return c.singleClientInfo()
+}
+
+func (c *Client) multiClientInfo() clientIntoList {
+	c.clientMu.RLock()
+	bCh := make(chan MQTTClientInfo, len(c.mqttClients))
+	c.clientMu.RUnlock()
+
+	_ = c.execute(func(cc mqtt.Client) error {
+		bCh <- transformClientInfo(cc)
+
+		return nil
+	}, execAll)
+
+	close(bCh)
+
+	bl := make(clientIntoList, 0, len(bCh))
+
+	for b := range bCh {
+		bl = append(bl, b)
+	}
+
+	sort.Slice(bl, func(i, j int) bool { return bl[i].ClientID < bl[j].ClientID })
+
+	return bl
+}
+
+func (c *Client) singleClientInfo() clientIntoList {
+	var bi MQTTClientInfo
+
+	_ = c.execute(func(cc mqtt.Client) error {
+		bi = transformClientInfo(cc)
+
+		return nil
+	}, execAll)
+
+	return clientIntoList{bi}
+}
+
+func transformClientInfo(cc mqtt.Client) MQTTClientInfo {
+	opts := cc.OptionsReader()
+
+	return MQTTClientInfo{
+		Addresses: slice.Map(opts.Servers(), func(u *url.URL) TCPAddress {
+			i, _ := strconv.Atoi(u.Port())
+
+			return TCPAddress{
+				Host: u.Hostname(),
+				Port: uint16(i),
+			}
+		}),
+		ClientID:      opts.ClientID(),
+		Username:      opts.Username(),
+		ResumeSubs:    opts.ResumeSubs(),
+		CleanSession:  opts.CleanSession(),
+		AutoReconnect: opts.AutoReconnect(),
+		Connected:     cc.IsConnected(),
+	}
+}

--- a/client_telemetry.go
+++ b/client_telemetry.go
@@ -155,7 +155,7 @@ func transformClientInfo(cc mqtt.Client, subscribedTopics ...string) MQTTClientI
 		ResumeSubs:    opts.ResumeSubs(),
 		CleanSession:  opts.CleanSession(),
 		AutoReconnect: opts.AutoReconnect(),
-		Connected:     cc.IsConnected(),
+		Connected:     cc.IsConnectionOpen(),
 		Subscriptions: subscribedTopics,
 	}
 }

--- a/client_telemetry_test.go
+++ b/client_telemetry_test.go
@@ -1,0 +1,40 @@
+package courier
+
+import (
+	"github.com/stretchr/testify/assert"
+	"sync"
+	"testing"
+)
+
+func TestClient_readSubscriptionMeta(t *testing.T) {
+	c := &Client{
+		subMu: sync.RWMutex{},
+		subscriptions: map[string]*subscriptionMeta{
+			"topic1": {
+				topic:   "topic1",
+				options: []Option{QOSOne},
+			},
+			"topic2": {
+				topic: "topic2",
+			},
+			"topic3": {
+				topic:   "topic3",
+				options: []Option{QOSTwo},
+			},
+		},
+	}
+
+	subs := c.readSubscriptionMeta()
+
+	assert.Equal(t, map[string]QOSLevel{
+		"topic1": 1,
+		"topic2": 0,
+		"topic3": 2,
+	}, subs)
+}
+
+func TestClient_clientInfo(t *testing.T) {
+	c := &Client{options: &clientOptions{}}
+	ci := c.clientInfo()
+	assert.Equal(t, []MQTTClientInfo(nil), ci)
+}

--- a/client_telemetry_test.go
+++ b/client_telemetry_test.go
@@ -1,9 +1,10 @@
 package courier
 
 import (
-	"github.com/stretchr/testify/assert"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_readSubscriptionMeta(t *testing.T) {

--- a/client_telemetry_test.go
+++ b/client_telemetry_test.go
@@ -35,7 +35,15 @@ func TestClient_readSubscriptionMeta(t *testing.T) {
 }
 
 func TestClient_clientInfo(t *testing.T) {
-	c := &Client{options: &clientOptions{}}
-	ci := c.clientInfo()
-	assert.Equal(t, []MQTTClientInfo(nil), ci)
+	t.Run("single connection mode", func(t *testing.T) {
+		c := &Client{options: &clientOptions{}}
+		ci := c.clientInfo()
+		assert.Equal(t, []MQTTClientInfo(nil), ci)
+	})
+
+	t.Run("multi connection mode", func(t *testing.T) {
+		c := &Client{options: &clientOptions{multiConnectionMode: true}}
+		ci := c.clientInfo()
+		assert.Equal(t, []MQTTClientInfo(nil), ci)
+	})
 }

--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -23,6 +23,7 @@ Package courier contains the client that can be used to interact with the courie
   - [func \(c \*Client\) Stop\(\)](#Client.Stop)
   - [func \(c \*Client\) Subscribe\(ctx context.Context, topic string, callback MessageHandler, opts ...Option\) error](#Client.Subscribe)
   - [func \(c \*Client\) SubscribeMultiple\(ctx context.Context, topicsWithQos map\[string\]QOSLevel, callback MessageHandler\) error](#Client.SubscribeMultiple)
+  - [func \(c \*Client\) TelemetryHandler\(\) http.Handler](#Client.TelemetryHandler)
   - [func \(c \*Client\) Unsubscribe\(ctx context.Context, topics ...string\) error](#Client.Unsubscribe)
   - [func \(c \*Client\) UsePublisherMiddleware\(mwf ...PublisherMiddlewareFunc\)](#Client.UsePublisherMiddleware)
   - [func \(c \*Client\) UseSubscriberMiddleware\(mwf ...SubscriberMiddlewareFunc\)](#Client.UseSubscriberMiddleware)
@@ -302,6 +303,15 @@ func (c *Client) SubscribeMultiple(ctx context.Context, topicsWithQos map[string
 ```
 
 SubscribeMultiple allows to subscribe to messages on multiple topics from an MQTT broker
+
+<a name="Client.TelemetryHandler"></a>
+### func \(\*Client\) [TelemetryHandler](https://github.com/gojek/courier-go/blob/main/http.go#L29)
+
+```go
+func (c *Client) TelemetryHandler() http.Handler
+```
+
+TelemetryHandler returns a http.Handler that exposes the connected brokers information
 
 <a name="Client.Unsubscribe"></a>
 ### func \(\*Client\) [Unsubscribe](https://github.com/gojek/courier-go/blob/main/client_unsubscribe.go#L10)

--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -1078,8 +1078,8 @@ TCPAddress specifies Host and Port for remote broker
 
 ```go
 type TCPAddress struct {
-    Host string
-    Port uint16
+    Host string `json:"host"`
+    Port uint16 `json:"port"`
 }
 ```
 

--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -30,6 +30,7 @@ Package courier contains the client that can be used to interact with the courie
   - [func \(c \*Client\) UseUnsubscriberMiddleware\(mwf ...UnsubscriberMiddlewareFunc\)](#Client.UseUnsubscriberMiddleware)
 - [type ClientInfoEmitter](#ClientInfoEmitter)
 - [type ClientInfoEmitterConfig](#ClientInfoEmitterConfig)
+- [type ClientMeta](#ClientMeta)
 - [type ClientOption](#ClientOption)
   - [func WithAddress\(host string, port uint16\) ClientOption](#WithAddress)
   - [func WithAutoReconnect\(autoReconnect bool\) ClientOption](#WithAutoReconnect)
@@ -353,18 +354,18 @@ func (c *Client) UseUnsubscriberMiddleware(mwf ...UnsubscriberMiddlewareFunc)
 UseUnsubscriberMiddleware appends a UnsubscriberMiddlewareFunc to the chain. Middleware can be used to intercept or otherwise modify, process or skip subscriptions. They are executed in the order that they are applied to the Client.
 
 <a name="ClientInfoEmitter"></a>
-## type [ClientInfoEmitter](https://github.com/gojek/courier-go/blob/main/metrics.go#L10-L12)
+## type [ClientInfoEmitter](https://github.com/gojek/courier-go/blob/main/metrics.go#L17-L19)
 
 ClientInfoEmitter emits broker info. This can be called concurrently, implementations should be concurrency safe.
 
 ```go
 type ClientInfoEmitter interface {
-    Emit(ctx context.Context, info MQTTClientInfo)
+    Emit(ctx context.Context, meta ClientMeta)
 }
 ```
 
 <a name="ClientInfoEmitterConfig"></a>
-## type [ClientInfoEmitterConfig](https://github.com/gojek/courier-go/blob/main/metrics.go#L15-L19)
+## type [ClientInfoEmitterConfig](https://github.com/gojek/courier-go/blob/main/metrics.go#L22-L26)
 
 ClientInfoEmitterConfig is used to configure the broker info emitter.
 
@@ -373,6 +374,19 @@ type ClientInfoEmitterConfig struct {
     // Interval is the interval at which the broker info emitter emits broker info.
     Interval time.Duration
     Emitter  ClientInfoEmitter
+}
+```
+
+<a name="ClientMeta"></a>
+## type [ClientMeta](https://github.com/gojek/courier-go/blob/main/metrics.go#L9-L13)
+
+ClientMeta contains information about the internal MQTT client\(s\)
+
+```go
+type ClientMeta struct {
+    MultiConnMode bool
+    Clients       []MQTTClientInfo
+    Subscriptions map[string]QOSLevel
 }
 ```
 

--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -273,7 +273,7 @@ func (c *Client) Publish(ctx context.Context, topic string, message interface{},
 Publish allows to publish messages to an MQTT broker
 
 <a name="Client.Run"></a>
-### func \(\*Client\) [Run](https://github.com/gojek/courier-go/blob/main/client.go#L118)
+### func \(\*Client\) [Run](https://github.com/gojek/courier-go/blob/main/client.go#L112)
 
 ```go
 func (c *Client) Run(ctx context.Context) error
@@ -291,7 +291,7 @@ func (c *Client) Start() error
 Start will attempt to connect to the broker.
 
 <a name="Client.Stop"></a>
-### func \(\*Client\) [Stop](https://github.com/gojek/courier-go/blob/main/client.go#L114)
+### func \(\*Client\) [Stop](https://github.com/gojek/courier-go/blob/main/client.go#L108)
 
 ```go
 func (c *Client) Stop()
@@ -754,7 +754,7 @@ type Logger interface {
 ```
 
 <a name="MQTTClientInfo"></a>
-## type [MQTTClientInfo](https://github.com/gojek/courier-go/blob/main/client_telemetry.go#L14-L25)
+## type [MQTTClientInfo](https://github.com/gojek/courier-go/blob/main/client_telemetry.go#L15-L26)
 
 MQTTClientInfo contains information about the internal MQTT client
 

--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -754,7 +754,7 @@ type Logger interface {
 ```
 
 <a name="MQTTClientInfo"></a>
-## type [MQTTClientInfo](https://github.com/gojek/courier-go/blob/main/client_telemetry.go#L14-L22)
+## type [MQTTClientInfo](https://github.com/gojek/courier-go/blob/main/client_telemetry.go#L14-L25)
 
 MQTTClientInfo contains information about the internal MQTT client
 
@@ -767,6 +767,9 @@ type MQTTClientInfo struct {
     CleanSession  bool         `json:"clean_session"`
     AutoReconnect bool         `json:"auto_reconnect"`
     Connected     bool         `json:"connected"`
+    // Subscriptions contains the topics the client is subscribed to
+    // Note: Currently, this field only holds shared subscriptions.
+    Subscriptions []string `json:"subscriptions,omitempty"`
 }
 ```
 

--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -16,6 +16,7 @@ Package courier contains the client that can be used to interact with the courie
 - [func WaitForConnection\(c ConnectionInformer, waitFor time.Duration, tick time.Duration\) bool](#WaitForConnection)
 - [type Client](#Client)
   - [func NewClient\(opts ...ClientOption\) \(\*Client, error\)](#NewClient)
+  - [func \(c \*Client\) InfoHandler\(\) http.Handler](#Client.InfoHandler)
   - [func \(c \*Client\) IsConnected\(\) bool](#Client.IsConnected)
   - [func \(c \*Client\) Publish\(ctx context.Context, topic string, message interface\{\}, opts ...Option\) error](#Client.Publish)
   - [func \(c \*Client\) Run\(ctx context.Context\) error](#Client.Run)
@@ -23,7 +24,6 @@ Package courier contains the client that can be used to interact with the courie
   - [func \(c \*Client\) Stop\(\)](#Client.Stop)
   - [func \(c \*Client\) Subscribe\(ctx context.Context, topic string, callback MessageHandler, opts ...Option\) error](#Client.Subscribe)
   - [func \(c \*Client\) SubscribeMultiple\(ctx context.Context, topicsWithQos map\[string\]QOSLevel, callback MessageHandler\) error](#Client.SubscribeMultiple)
-  - [func \(c \*Client\) TelemetryHandler\(\) http.Handler](#Client.TelemetryHandler)
   - [func \(c \*Client\) Unsubscribe\(ctx context.Context, topics ...string\) error](#Client.Unsubscribe)
   - [func \(c \*Client\) UsePublisherMiddleware\(mwf ...PublisherMiddlewareFunc\)](#Client.UsePublisherMiddleware)
   - [func \(c \*Client\) UseSubscriberMiddleware\(mwf ...SubscriberMiddlewareFunc\)](#Client.UseSubscriberMiddleware)
@@ -244,6 +244,15 @@ c.Stop()
 </p>
 </details>
 
+<a name="Client.InfoHandler"></a>
+### func \(\*Client\) [InfoHandler](https://github.com/gojek/courier-go/blob/main/http.go#L9)
+
+```go
+func (c *Client) InfoHandler() http.Handler
+```
+
+InfoHandler returns a http.Handler that exposes the connected clients information
+
 <a name="Client.IsConnected"></a>
 ### func \(\*Client\) [IsConnected](https://github.com/gojek/courier-go/blob/main/client.go#L84)
 
@@ -306,15 +315,6 @@ func (c *Client) SubscribeMultiple(ctx context.Context, topicsWithQos map[string
 ```
 
 SubscribeMultiple allows to subscribe to messages on multiple topics from an MQTT broker
-
-<a name="Client.TelemetryHandler"></a>
-### func \(\*Client\) [TelemetryHandler](https://github.com/gojek/courier-go/blob/main/http.go#L9)
-
-```go
-func (c *Client) TelemetryHandler() http.Handler
-```
-
-TelemetryHandler returns a http.Handler that exposes the connected clients information
 
 <a name="Client.Unsubscribe"></a>
 ### func \(\*Client\) [Unsubscribe](https://github.com/gojek/courier-go/blob/main/client_unsubscribe.go#L10)

--- a/exec.go
+++ b/exec.go
@@ -16,6 +16,7 @@ import (
 var errInvalidExecOpt = errors.New("courier: invalid exec option")
 
 type internalState struct {
+	// currently holds only shared subscriptions info
 	subsCalled generic.Set[string]
 	client     mqtt.Client
 	mu         sync.Mutex

--- a/http.go
+++ b/http.go
@@ -8,13 +8,10 @@ import (
 // InfoHandler returns a http.Handler that exposes the connected clients information
 func (c *Client) InfoHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		cl := c.allClientInfo()
+		ir := c.infoResponse()
 
 		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"multi":   c.options.multiConnectionMode,
-			"clients": cl,
-		})
+		_ = json.NewEncoder(w).Encode(ir)
 	})
 }

--- a/http.go
+++ b/http.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 )
 
-// TelemetryHandler returns a http.Handler that exposes the connected clients information
-func (c *Client) TelemetryHandler() http.Handler {
+// InfoHandler returns a http.Handler that exposes the connected clients information
+func (c *Client) InfoHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		cl := c.allClientInfo()
 

--- a/http.go
+++ b/http.go
@@ -2,100 +2,19 @@ package courier
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"net/url"
-	"sort"
-	"strconv"
-
-	mqtt "github.com/eclipse/paho.mqtt.golang"
-
-	"github.com/gojekfarm/xtools/generic/slice"
 )
 
-type brokerList []broker
-
-type broker struct {
-	Addresses     []TCPAddress `json:"addresses"`
-	ClientID      string       `json:"client_id"`
-	Username      string       `json:"username"`
-	ResumeSubs    bool         `json:"resume_subs"`
-	CleanSession  bool         `json:"clean_session"`
-	AutoReconnect bool         `json:"auto_reconnect"`
-	Connected     bool         `json:"connected"`
-}
-
-// TelemetryHandler returns a http.Handler that exposes the connected brokers information
+// TelemetryHandler returns a http.Handler that exposes the connected clients information
 func (c *Client) TelemetryHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !c.options.multiConnectionMode {
-			var bi broker
+		cl := c.allClientInfo()
 
-			err := c.execute(func(cc mqtt.Client) error {
-				bi = brokerInfo(cc)
-
-				return nil
-			}, execAll)
-
-			writeResponse(w, brokerList{bi}, err, false)
-
-			return
-		}
-
-		var bl brokerList
-		bCh := make(chan broker, len(c.mqttClients))
-
-		err := c.execute(func(cc mqtt.Client) error {
-			bCh <- brokerInfo(cc)
-
-			return nil
-		}, execAll)
-
-		close(bCh)
-
-		for b := range bCh {
-			bl = append(bl, b)
-		}
-
-		sort.Slice(bl, func(i, j int) bool { return bl[i].ClientID < bl[j].ClientID })
-
-		writeResponse(w, bl, err, true)
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"multi":   c.options.multiConnectionMode,
+			"clients": cl,
+		})
 	})
-}
-
-func writeResponse(w http.ResponseWriter, list brokerList, err error, multi bool) {
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = fmt.Fprintf(w, `{"error": "%s"}`, err.Error())
-
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]any{
-		"multi":   multi,
-		"brokers": list,
-	})
-}
-
-func brokerInfo(cc mqtt.Client) broker {
-	opts := cc.OptionsReader()
-
-	return broker{
-		Addresses: slice.Map(opts.Servers(), func(u *url.URL) TCPAddress {
-			i, _ := strconv.Atoi(u.Port())
-
-			return TCPAddress{
-				Host: u.Hostname(),
-				Port: uint16(i),
-			}
-		}),
-		ClientID:      opts.ClientID(),
-		Username:      opts.Username(),
-		ResumeSubs:    opts.ResumeSubs(),
-		CleanSession:  opts.CleanSession(),
-		AutoReconnect: opts.AutoReconnect(),
-		Connected:     cc.IsConnected(),
-	}
 }

--- a/http.go
+++ b/http.go
@@ -1,0 +1,101 @@
+package courier
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+
+	"github.com/gojekfarm/xtools/generic/slice"
+)
+
+type brokerList []broker
+
+type broker struct {
+	Addresses     []TCPAddress `json:"addresses"`
+	ClientID      string       `json:"client_id"`
+	Username      string       `json:"username"`
+	ResumeSubs    bool         `json:"resume_subs"`
+	CleanSession  bool         `json:"clean_session"`
+	AutoReconnect bool         `json:"auto_reconnect"`
+	Connected     bool         `json:"connected"`
+}
+
+// TelemetryHandler returns a http.Handler that exposes the connected brokers information
+func (c *Client) TelemetryHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !c.options.multiConnectionMode {
+			var bi broker
+
+			err := c.execute(func(cc mqtt.Client) error {
+				bi = brokerInfo(cc)
+
+				return nil
+			}, execAll)
+
+			writeResponse(w, brokerList{bi}, err, false)
+
+			return
+		}
+
+		var bl brokerList
+		bCh := make(chan broker, len(c.mqttClients))
+
+		err := c.execute(func(cc mqtt.Client) error {
+			bCh <- brokerInfo(cc)
+
+			return nil
+		}, execAll)
+
+		close(bCh)
+
+		for b := range bCh {
+			bl = append(bl, b)
+		}
+
+		sort.Slice(bl, func(i, j int) bool { return bl[i].ClientID < bl[j].ClientID })
+
+		writeResponse(w, bl, err, true)
+	})
+}
+
+func writeResponse(w http.ResponseWriter, list brokerList, err error, multi bool) {
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprintf(w, `{"error": "%s"}`, err.Error())
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"multi":   multi,
+		"brokers": list,
+	})
+}
+
+func brokerInfo(cc mqtt.Client) broker {
+	opts := cc.OptionsReader()
+
+	return broker{
+		Addresses: slice.Map(opts.Servers(), func(u *url.URL) TCPAddress {
+			i, _ := strconv.Atoi(u.Port())
+
+			return TCPAddress{
+				Host: u.Hostname(),
+				Port: uint16(i),
+			}
+		}),
+		ClientID:      opts.ClientID(),
+		Username:      opts.Username(),
+		ResumeSubs:    opts.ResumeSubs(),
+		CleanSession:  opts.CleanSession(),
+		AutoReconnect: opts.AutoReconnect(),
+		Connected:     cc.IsConnected(),
+	}
+}

--- a/http_test.go
+++ b/http_test.go
@@ -69,7 +69,7 @@ func TestClient_TelemetryHandler(t *testing.T) {
 				_ = c.Run(ctx)
 			}()
 
-			h := c.TelemetryHandler()
+			h := c.InfoHandler()
 
 			assert.True(t, WaitForConnection(c, 2*time.Second, 100*time.Millisecond))
 

--- a/http_test.go
+++ b/http_test.go
@@ -1,0 +1,95 @@
+package courier
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient_TelemetryHandler(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		opts   func(*testing.T) []ClientOption
+	}{
+		{
+			name:   "single connection mode",
+			status: http.StatusOK,
+			opts:   func(t *testing.T) []ClientOption { return nil },
+			body: fmt.Sprintf(`{"brokers":[{"addresses":[{"Host":"%s","Port":%d}],"client_id":"clientID","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true}],"multi":false}
+`, testBrokerAddress.Host, testBrokerAddress.Port),
+		},
+		{
+			name:   "multi connection mode",
+			status: http.StatusOK,
+			opts: func(t *testing.T) []ClientOption {
+				ch := make(chan []TCPAddress, 1)
+				dCh := make(chan struct{})
+				mr := newMockResolver(t)
+
+				mr.On("UpdateChan").Return(ch)
+				mr.On("Done").Return(dCh)
+
+				go func() {
+					ch <- []TCPAddress{testBrokerAddress, testBrokerAddress}
+
+					<-time.After(2 * time.Second)
+					close(ch)
+
+					dCh <- struct{}{}
+				}()
+
+				return []ClientOption{
+					WithResolver(mr),
+					UseMultiConnectionMode,
+				}
+			},
+			body: fmt.Sprintf(`{"brokers":[{"addresses":[{"Host":"%s","Port":%d}],"client_id":"clientID-0-1","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true},{"addresses":[{"Host":"%s","Port":%d}],"client_id":"clientID-1-1","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true}],"multi":true}
+`, testBrokerAddress.Host, testBrokerAddress.Port, testBrokerAddress.Host, testBrokerAddress.Port),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eOpts := tt.opts(t)
+
+			c, err := NewClient(append(defOpts, eOpts...)...)
+			assert.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			go func() {
+				_ = c.Run(ctx)
+			}()
+
+			h := c.TelemetryHandler()
+
+			assert.True(t, WaitForConnection(c, 2*time.Second, 100*time.Millisecond))
+
+			req := httptest.NewRequest(http.MethodGet, "/telemetry", nil)
+			rr := httptest.NewRecorder()
+
+			h.ServeHTTP(rr, req)
+
+			assert.Equal(t, tt.status, rr.Code)
+			assert.Equal(t, tt.body, rr.Body.String())
+		})
+	}
+}
+
+func Test_writeResponse_error(t *testing.T) {
+	rr := httptest.NewRecorder()
+
+	writeResponse(rr, nil, errors.New("error"), false)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Equal(t, `{"error": "error"}`, rr.Body.String())
+}

--- a/http_test.go
+++ b/http_test.go
@@ -2,7 +2,6 @@ package courier
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -23,7 +22,7 @@ func TestClient_TelemetryHandler(t *testing.T) {
 			name:   "single connection mode",
 			status: http.StatusOK,
 			opts:   func(t *testing.T) []ClientOption { return nil },
-			body: fmt.Sprintf(`{"brokers":[{"addresses":[{"Host":"%s","Port":%d}],"client_id":"clientID","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true}],"multi":false}
+			body: fmt.Sprintf(`{"clients":[{"addresses":[{"Host":"%s","Port":%d}],"client_id":"clientID","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true}],"multi":false}
 `, testBrokerAddress.Host, testBrokerAddress.Port),
 		},
 		{
@@ -51,7 +50,7 @@ func TestClient_TelemetryHandler(t *testing.T) {
 					UseMultiConnectionMode,
 				}
 			},
-			body: fmt.Sprintf(`{"brokers":[{"addresses":[{"Host":"%s","Port":%d}],"client_id":"clientID-0-1","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true},{"addresses":[{"Host":"%s","Port":%d}],"client_id":"clientID-1-1","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true}],"multi":true}
+			body: fmt.Sprintf(`{"clients":[{"addresses":[{"Host":"%s","Port":%d}],"client_id":"clientID-0-1","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true},{"addresses":[{"Host":"%s","Port":%d}],"client_id":"clientID-1-1","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true}],"multi":true}
 `, testBrokerAddress.Host, testBrokerAddress.Port, testBrokerAddress.Host, testBrokerAddress.Port),
 		},
 	}
@@ -83,13 +82,4 @@ func TestClient_TelemetryHandler(t *testing.T) {
 			assert.Equal(t, tt.body, rr.Body.String())
 		})
 	}
-}
-
-func Test_writeResponse_error(t *testing.T) {
-	rr := httptest.NewRecorder()
-
-	writeResponse(rr, nil, errors.New("error"), false)
-
-	assert.Equal(t, http.StatusInternalServerError, rr.Code)
-	assert.Equal(t, `{"error": "error"}`, rr.Body.String())
 }

--- a/http_test.go
+++ b/http_test.go
@@ -22,7 +22,7 @@ func TestClient_TelemetryHandler(t *testing.T) {
 			name:   "single connection mode",
 			status: http.StatusOK,
 			opts:   func(t *testing.T) []ClientOption { return nil },
-			body: fmt.Sprintf(`{"clients":[{"addresses":[{"host":"%s","port":%d}],"client_id":"clientID","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true}],"multi":false}
+			body: fmt.Sprintf(`{"multi":false,"clients":[{"addresses":[{"host":"%s","port":%d}],"client_id":"clientID","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true}]}
 `, testBrokerAddress.Host, testBrokerAddress.Port),
 		},
 		{
@@ -50,7 +50,7 @@ func TestClient_TelemetryHandler(t *testing.T) {
 					UseMultiConnectionMode,
 				}
 			},
-			body: fmt.Sprintf(`{"clients":[{"addresses":[{"host":"%s","port":%d}],"client_id":"clientID-0-1","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true},{"addresses":[{"host":"%s","port":%d}],"client_id":"clientID-1-1","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true}],"multi":true}
+			body: fmt.Sprintf(`{"multi":true,"clients":[{"addresses":[{"host":"%s","port":%d}],"client_id":"clientID-0-1","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true},{"addresses":[{"host":"%s","port":%d}],"client_id":"clientID-1-1","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true}]}
 `, testBrokerAddress.Host, testBrokerAddress.Port, testBrokerAddress.Host, testBrokerAddress.Port),
 		},
 	}

--- a/http_test.go
+++ b/http_test.go
@@ -22,7 +22,7 @@ func TestClient_TelemetryHandler(t *testing.T) {
 			name:   "single connection mode",
 			status: http.StatusOK,
 			opts:   func(t *testing.T) []ClientOption { return nil },
-			body: fmt.Sprintf(`{"clients":[{"addresses":[{"Host":"%s","Port":%d}],"client_id":"clientID","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true}],"multi":false}
+			body: fmt.Sprintf(`{"clients":[{"addresses":[{"host":"%s","port":%d}],"client_id":"clientID","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true}],"multi":false}
 `, testBrokerAddress.Host, testBrokerAddress.Port),
 		},
 		{
@@ -50,7 +50,7 @@ func TestClient_TelemetryHandler(t *testing.T) {
 					UseMultiConnectionMode,
 				}
 			},
-			body: fmt.Sprintf(`{"clients":[{"addresses":[{"Host":"%s","Port":%d}],"client_id":"clientID-0-1","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true},{"addresses":[{"Host":"%s","Port":%d}],"client_id":"clientID-1-1","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true}],"multi":true}
+			body: fmt.Sprintf(`{"clients":[{"addresses":[{"host":"%s","port":%d}],"client_id":"clientID-0-1","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true},{"addresses":[{"host":"%s","port":%d}],"client_id":"clientID-1-1","username":"","resume_subs":false,"clean_session":false,"auto_reconnect":true,"connected":true}],"multi":true}
 `, testBrokerAddress.Host, testBrokerAddress.Port, testBrokerAddress.Host, testBrokerAddress.Port),
 		},
 	}

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,41 @@
+package courier
+
+import (
+	"context"
+	"time"
+)
+
+// ClientInfoEmitter emits broker info.
+// This can be called concurrently, implementations should be concurrency safe.
+type ClientInfoEmitter interface {
+	Emit(ctx context.Context, info MQTTClientInfo)
+}
+
+// ClientInfoEmitterConfig is used to configure the broker info emitter.
+type ClientInfoEmitterConfig struct {
+	// Interval is the interval at which the broker info emitter emits broker info.
+	Interval time.Duration
+	Emitter  ClientInfoEmitter
+}
+
+func (cfg *ClientInfoEmitterConfig) apply(o *clientOptions) { o.infoEmitterCfg = cfg }
+
+func (c *Client) runBrokerInfoEmitter(ctx context.Context) {
+	tick := time.NewTicker(c.options.infoEmitterCfg.Interval)
+	defer tick.Stop()
+
+	em := c.options.infoEmitterCfg.Emitter
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+			cl := c.allClientInfo()
+
+			for _, ci := range cl {
+				go em.Emit(ctx, ci)
+			}
+		}
+	}
+}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -20,7 +20,7 @@ func newMockEmitter(t *testing.T) *mockEmitter {
 	return m
 }
 
-func (m *mockEmitter) Emit(ctx context.Context, info MQTTClientInfo) { m.Called(ctx, info) }
+func (m *mockEmitter) Emit(ctx context.Context, meta ClientMeta) { m.Called(ctx, meta) }
 
 func TestClient_ClientInfoEmitter(t *testing.T) {
 	tests := []struct {
@@ -52,7 +52,7 @@ func TestClient_ClientInfoEmitter(t *testing.T) {
 				go func() {
 					ch <- []TCPAddress{testBrokerAddress, testBrokerAddress}
 
-					<-time.After(2 * time.Second)
+					<-time.After(time.Second + 500*time.Millisecond)
 					close(ch)
 
 					dCh <- struct{}{}
@@ -64,11 +64,11 @@ func TestClient_ClientInfoEmitter(t *testing.T) {
 				}
 			},
 			mock: func(wg *sync.WaitGroup, m *mock.Mock) {
-				wg.Add(2)
+				wg.Add(1)
 
 				m.On("Emit", mock.Anything, mock.Anything).Return().Run(func(args mock.Arguments) {
 					wg.Done()
-				}).Twice()
+				}).Once()
 			},
 		},
 	}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,0 +1,116 @@
+package courier
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockEmitter struct {
+	mock.Mock
+}
+
+func newMockEmitter(t *testing.T) *mockEmitter {
+	m := &mockEmitter{}
+	m.Test(t)
+	return m
+}
+
+func (m *mockEmitter) Emit(ctx context.Context, info MQTTClientInfo) { m.Called(ctx, info) }
+
+func TestClient_ClientInfoEmitter(t *testing.T) {
+	tests := []struct {
+		name string
+		mock func(*sync.WaitGroup, *mock.Mock)
+		opts func(*testing.T) []ClientOption
+	}{
+		{
+			name: "single connection mode",
+			opts: func(t *testing.T) []ClientOption { return nil },
+			mock: func(wg *sync.WaitGroup, m *mock.Mock) {
+				wg.Add(1)
+
+				m.On("Emit", mock.Anything, mock.Anything).Return().Run(func(args mock.Arguments) {
+					wg.Done()
+				}).Once()
+			},
+		},
+		{
+			name: "multi connection mode",
+			opts: func(t *testing.T) []ClientOption {
+				ch := make(chan []TCPAddress, 1)
+				dCh := make(chan struct{})
+				mr := newMockResolver(t)
+
+				mr.On("UpdateChan").Return(ch)
+				mr.On("Done").Return(dCh)
+
+				go func() {
+					ch <- []TCPAddress{testBrokerAddress, testBrokerAddress}
+
+					<-time.After(2 * time.Second)
+					close(ch)
+
+					dCh <- struct{}{}
+				}()
+
+				return []ClientOption{
+					WithResolver(mr),
+					UseMultiConnectionMode,
+				}
+			},
+			mock: func(wg *sync.WaitGroup, m *mock.Mock) {
+				wg.Add(2)
+
+				m.On("Emit", mock.Anything, mock.Anything).Return().Run(func(args mock.Arguments) {
+					wg.Done()
+				}).Twice()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eOpts := tt.opts(t)
+			mc := newMockEmitter(t)
+			eOpts = append(eOpts, &ClientInfoEmitterConfig{
+				Interval: time.Second,
+				Emitter:  mc,
+			})
+
+			wg := &sync.WaitGroup{}
+			if tt.mock != nil {
+				tt.mock(wg, &mc.Mock)
+			}
+
+			c, err := NewClient(append(defOpts, eOpts...)...)
+			assert.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(context.Background())
+
+			go func() {
+				_ = c.Run(ctx)
+			}()
+
+			assert.True(t, WaitForConnection(c, 2*time.Second, 100*time.Millisecond))
+
+			wg.Wait()
+
+			cancel()
+
+			mc.AssertExpectations(t)
+		})
+	}
+
+	t.Run("NewClientWithLessThanOneSecondEmitterIntervalError", func(t *testing.T) {
+		_, err := NewClient(append(defOpts, &ClientInfoEmitterConfig{
+			Interval: 100 * time.Millisecond,
+			Emitter:  newMockEmitter(t),
+		})...)
+		assert.EqualError(t, err, "client info emitter interval must be greater than or equal to 1s")
+	})
+}


### PR DESCRIPTION
This adds an HTTP handler that can reveal the state of established clients at any moment. It also gives a way to get notified of changes happening to clients.