### PR TITLE
Update multi-connection mode connect logic

### DIFF
--- a/client.go
+++ b/client.go
@@ -34,7 +34,7 @@ type Client struct {
 	usMiddlewares []unsubscribeMiddleware
 
 	rrCounter         *atomicCounter
-	multiConnRevision uint64
+	multiConnRevision atomic.Uint64
 	rndPool           *sync.Pool
 	clientMu          sync.RWMutex
 	subMu             sync.RWMutex
@@ -212,6 +212,11 @@ func toClientOptions(c *Client, o *clientOptions, idSuffix string) *mqtt.ClientO
 	}
 
 	setCredentials(o, opts)
+
+	if o.multiConnectionMode {
+		opts.SetConnectRetry(true)
+		opts.SetConnectRetryInterval(2 * time.Second)
+	}
 
 	opts.AddBroker(formatAddressWithProtocol(o)).
 		SetTLSConfig(o.tlsConfig).

--- a/client.go
+++ b/client.go
@@ -218,11 +218,6 @@ func toClientOptions(c *Client, o *clientOptions, idSuffix string) *mqtt.ClientO
 		opts.SetConnectRetryInterval(o.connectRetryPolicy.interval)
 	}
 
-	if o.multiConnectionMode {
-		opts.SetConnectRetry(true)
-		opts.SetConnectRetryInterval(2 * time.Second)
-	}
-
 	opts.AddBroker(formatAddressWithProtocol(o)).
 		SetTLSConfig(o.tlsConfig).
 		SetAutoReconnect(o.autoReconnect).

--- a/client.go
+++ b/client.go
@@ -213,6 +213,11 @@ func toClientOptions(c *Client, o *clientOptions, idSuffix string) *mqtt.ClientO
 
 	setCredentials(o, opts)
 
+	if o.connectRetryPolicy.enabled {
+		opts.SetConnectRetry(true)
+		opts.SetConnectRetryInterval(o.connectRetryPolicy.interval)
+	}
+
 	if o.multiConnectionMode {
 		opts.SetConnectRetry(true)
 		opts.SetConnectRetryInterval(2 * time.Second)

--- a/client_options.go
+++ b/client_options.go
@@ -211,12 +211,11 @@ func WithExponentialStartOptions(options ...StartOption) ClientOption {
 	})
 }
 
-// MultiConnectRetryInterval allows to configure the interval between connection retries.
-// It should be used with UseMultiConnectionMode.
+// ConnectRetryInterval allows to configure the interval between connection retries.
 // Default value is 10 seconds.
-type MultiConnectRetryInterval time.Duration
+type ConnectRetryInterval time.Duration
 
-func (i MultiConnectRetryInterval) apply(o *clientOptions) {
+func (i ConnectRetryInterval) apply(o *clientOptions) {
 	o.connectRetryPolicy.enabled = true
 	o.connectRetryPolicy.interval = time.Duration(i)
 }

--- a/client_options_test.go
+++ b/client_options_test.go
@@ -216,6 +216,7 @@ func (s *ClientOptionSuite) Test_defaultOptions() {
 		gracefulShutdownPeriod:      30 * time.Second,
 		keepAlive:                   60 * time.Second,
 		credentialFetchTimeout:      10 * time.Second,
+		connectRetryPolicy:          connectRetryPolicy{interval: 10 * time.Second},
 		newEncoder:                  DefaultEncoderFunc,
 		newDecoder:                  DefaultDecoderFunc,
 		store:                       inMemoryPersistence,

--- a/client_options_test.go
+++ b/client_options_test.go
@@ -191,6 +191,11 @@ func (s *ClientOptionSuite) Test_function_based_apply() {
 			option: SharedSubscriptionPredicate(ssp),
 			want:   &clientOptions{sharedSubscriptionPredicate: ssp},
 		},
+		{
+			name:   "MultiConnectRetryInterval",
+			option: MultiConnectRetryInterval(time.Second),
+			want:   &clientOptions{connectRetryPolicy: connectRetryPolicy{enabled: true, interval: time.Second}},
+		},
 	}
 
 	for _, t := range tests {

--- a/client_options_test.go
+++ b/client_options_test.go
@@ -192,8 +192,8 @@ func (s *ClientOptionSuite) Test_function_based_apply() {
 			want:   &clientOptions{sharedSubscriptionPredicate: ssp},
 		},
 		{
-			name:   "MultiConnectRetryInterval",
-			option: MultiConnectRetryInterval(time.Second),
+			name:   "ConnectRetryInterval",
+			option: ConnectRetryInterval(time.Second),
 			want:   &clientOptions{connectRetryPolicy: connectRetryPolicy{enabled: true, interval: time.Second}},
 		},
 	}

--- a/client_resolver.go
+++ b/client_resolver.go
@@ -111,6 +111,8 @@ func (c *Client) reloadClients(clients map[string]mqtt.Client) {
 
 	go func(oldClients []mqtt.Client, newClientsLen int) {
 		if len(oldClients) == 0 || newClientsLen == 0 {
+			c.options.logger.Info(context.Background(), "skippind disconnections", map[string]any{})
+
 			return
 		}
 
@@ -120,6 +122,11 @@ func (c *Client) reloadClients(clients map[string]mqtt.Client) {
 
 func (c *Client) disconnectAll(cls []mqtt.Client) {
 	slice.MapConcurrent(cls, func(cc mqtt.Client) error {
+		r := cc.OptionsReader()
+		c.options.logger.Info(context.Background(), "disconnecting client", map[string]any{
+			"clientID": r.ClientID(),
+		})
+
 		cc.Disconnect(uint(c.options.gracefulShutdownPeriod / time.Millisecond))
 
 		return nil

--- a/client_resolver.go
+++ b/client_resolver.go
@@ -71,6 +71,9 @@ func (c *Client) attemptMultiConnections(addrs []TCPAddress) error {
 }
 
 func (c *Client) refreshClients(addrs []TCPAddress) error {
+	c.clientMu.Lock()
+	defer c.clientMu.Unlock()
+
 	clients := c.multipleClients(addrs)
 
 	c.reloadClients(clients)
@@ -92,9 +95,6 @@ func (c *Client) resumeSubscriptions() error {
 }
 
 func (c *Client) reloadClients(clients map[string]mqtt.Client) {
-	c.clientMu.Lock()
-	defer c.clientMu.Unlock()
-
 	oldClients := xmap.Values(c.mqttClients)
 
 	if len(clients) > 0 {

--- a/client_resolver.go
+++ b/client_resolver.go
@@ -74,10 +74,7 @@ func (c *Client) refreshClients(addrs []TCPAddress) error {
 	c.clientMu.Lock()
 	defer c.clientMu.Unlock()
 
-	clients, err := c.multipleClients(addrs)
-	if err != nil {
-		return err
-	}
+	clients := c.multipleClients(addrs)
 
 	c.reloadClients(clients)
 
@@ -101,17 +98,32 @@ func (c *Client) reloadClients(clients map[string]mqtt.Client) {
 	oldClients := xmap.Values(c.mqttClients)
 	c.mqttClients = clients
 
-	go func(oldClients []mqtt.Client) {
-		if len(oldClients) == 0 {
+	c.options.logger.Info(context.Background(), "reloading clients", map[string]any{
+		"oldIds": slice.Map(oldClients, func(cc mqtt.Client) string {
+			r := cc.OptionsReader()
+			return r.ClientID()
+		}),
+		"newIds": slice.Map(xmap.Values(clients), func(cc mqtt.Client) string {
+			r := cc.OptionsReader()
+			return r.ClientID()
+		}),
+	})
+
+	go func(oldClients []mqtt.Client, newClientsLen int) {
+		if len(oldClients) == 0 || newClientsLen == 0 {
 			return
 		}
 
-		slice.MapConcurrent(oldClients, func(cc mqtt.Client) error {
-			cc.Disconnect(uint(c.options.gracefulShutdownPeriod / time.Millisecond))
+		c.disconnectAll(oldClients)
+	}(oldClients, len(clients))
+}
 
-			return nil
-		})
-	}(oldClients)
+func (c *Client) disconnectAll(cls []mqtt.Client) {
+	slice.MapConcurrent(cls, func(cc mqtt.Client) error {
+		cc.Disconnect(uint(c.options.gracefulShutdownPeriod / time.Millisecond))
+
+		return nil
+	})
 }
 
 type indexAddress struct {
@@ -119,50 +131,85 @@ type indexAddress struct {
 	addr  TCPAddress
 }
 
-func (c *Client) multipleClients(addrs []TCPAddress) (map[string]mqtt.Client, error) {
+func (c *Client) multipleClients(addrs []TCPAddress) map[string]mqtt.Client {
 	clients := &sync.Map{}
+
+	currRev := c.multiConnRevision.Load()
+	c.options.logger.Info(context.Background(), "attempting multiple connections", map[string]any{
+		"multiConnRevision": currRev,
+	})
 
 	i := &atomicCounter{}
 	iaddrs := slice.Map(addrs, func(a TCPAddress) indexAddress { return indexAddress{index: int(i.next()), addr: a} })
 
-	if err := slice.Reduce(slice.MapConcurrent(iaddrs, func(ia indexAddress) error {
+	slice.MapConcurrent(iaddrs, func(ia indexAddress) error {
 		opts := *c.options
 		opts.brokerAddress = ia.addr.String()
 
-		cc := newClientFunc.Load().(func(*mqtt.ClientOptions) mqtt.Client)(
-			toClientOptions(c, &opts, fmt.Sprintf("-%d-%d", ia.index, c.multiConnRevision+1)),
-		)
+		pOpts := toClientOptions(c, &opts, fmt.Sprintf("-%d-%d", ia.index, currRev+1))
+		cc := newClientFunc.Load().(func(*mqtt.ClientOptions) mqtt.Client)(pOpts)
+
+		clients.Store(ia.addr.String(), cc)
+
+		c.options.logger.Info(context.Background(), "attempting connection", map[string]any{
+			"multiConnRevision": currRev,
+			"clientID":          pOpts.ClientID,
+		})
 
 		t := cc.Connect()
 		if !t.WaitTimeout(c.options.connectTimeout) {
+			c.options.logger.Error(context.Background(), ErrConnectTimeout, map[string]any{
+				"clientID": pOpts.ClientID,
+			})
 			return ErrConnectTimeout
 		}
 
 		if err := t.Error(); err != nil {
+			c.options.logger.Error(context.Background(), err, map[string]any{
+				"clientID": pOpts.ClientID,
+			})
+
 			return err
 		}
 
-		clients.Store(ia.addr.String(), cc)
-
 		return nil
-	}), accumulateErrors); err != nil {
-		return nil, err
-	}
-
-	if len(iaddrs) > 0 {
-		c.multiConnRevision++
-	}
+	})
 
 	res := map[string]mqtt.Client{}
+	anyConnected := false
 
 	clients.Range(func(key, value interface{}) bool {
+		cc := value.(mqtt.Client)
+		if cc.IsConnectionOpen() {
+			anyConnected = true
+		}
 		// nolint: errcheck
-		res[key.(string)] = value.(mqtt.Client)
+		res[key.(string)] = cc
 
 		return true
 	})
 
-	return res, nil
+	if !anyConnected {
+		c.options.logger.Info(context.Background(), "no clients connected", map[string]any{
+			"multiConnRevision": currRev,
+		})
+
+		go c.disconnectAll(xmap.Values(res))
+
+		res = nil
+	}
+
+	if len(res) > 0 {
+		if c.multiConnRevision.CompareAndSwap(currRev, currRev+1) {
+			c.options.logger.Info(context.Background(), "multiConnRevision incremented", map[string]any{
+				"old":               currRev,
+				"new":               currRev + 1,
+				"multiConnRevision": c.multiConnRevision.Load(),
+			})
+		}
+	}
+
+	return res
 }
 
 func (c *Client) newClient(addrs []TCPAddress, attempt int) mqtt.Client {

--- a/client_resolver.go
+++ b/client_resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -108,9 +109,8 @@ func (c *Client) reloadClients(clients map[string]mqtt.Client) {
 
 func (c *Client) disconnectAll(cls []mqtt.Client) {
 	slice.MapConcurrent(cls, func(cc mqtt.Client) error {
-		r := cc.OptionsReader()
 		c.options.logger.Info(context.Background(), "disconnecting client", map[string]any{
-			"clientID": r.ClientID(),
+			"clientID": clientIDMapper(cc),
 		})
 
 		cc.Disconnect(uint(c.options.gracefulShutdownPeriod / time.Millisecond))
@@ -273,6 +273,10 @@ func singleLineFormatFunc(es []error) string {
 
 func clientIDMapper(cc mqtt.Client) string {
 	r := cc.OptionsReader()
+
+	if reflect.ValueOf(r).FieldByName("options").IsNil() {
+		return "<nil-options>"
+	}
 
 	return r.ClientID()
 }

--- a/client_resolver_test.go
+++ b/client_resolver_test.go
@@ -240,7 +240,7 @@ func TestClient_multiClientConnectionAttempts(t *testing.T) {
 
 			newClientFunc.Store(func(o *mqtt.ClientOptions) mqtt.Client { return tt.newClientFunc(t, o) })
 
-			got, err := c.multipleClients(tt.addrs)
+			got := c.multipleClients(tt.addrs)
 
 			tt.wantErr(t, err)
 

--- a/client_resolver_test.go
+++ b/client_resolver_test.go
@@ -815,3 +815,30 @@ func Test_accumulateErrors(t *testing.T) {
 		})
 	}
 }
+
+func Test_clientIDMapper(t *testing.T) {
+	tests := []struct {
+		name string
+		cc   mqtt.Client
+		want string
+	}{
+		{
+			name: "nil_options",
+			cc:   &mockClient{},
+			want: "<nil-options>",
+		},
+		{
+			name: "non_nil_options",
+			cc: mqtt.NewClient(&mqtt.ClientOptions{
+				ClientID: "client_id",
+			}),
+			want: "client_id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, clientIDMapper(tt.cc), "clientIDMapper(%v)", tt.cc)
+		})
+	}
+}

--- a/client_resolver_test.go
+++ b/client_resolver_test.go
@@ -167,12 +167,10 @@ func TestClient_multiClientConnectionAttempts(t *testing.T) {
 		addrs         []TCPAddress
 		newClientFunc func(*testing.T, *mqtt.ClientOptions) mqtt.Client
 		logMock       func(*mock.Mock)
-		wantErr       assert.ErrorAssertionFunc
 	}{
 		{
-			name:    "success",
-			wantErr: assert.NoError,
-			addrs:   addresses,
+			name:  "success",
+			addrs: addresses,
 			newClientFunc: func(t *testing.T, o *mqtt.ClientOptions) mqtt.Client {
 				m := newMockClient(t)
 				tkn := newMockToken(t)
@@ -198,14 +196,6 @@ func TestClient_multiClientConnectionAttempts(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				merr := &multierror.Error{Errors: []error{
-					ErrConnectTimeout,
-					ErrConnectTimeout,
-				}, ErrorFormat: singleLineFormatFunc}
-
-				return assert.EqualError(t, err, merr.Error())
-			},
 		},
 		{
 			name:  "token_error",
@@ -221,14 +211,6 @@ func TestClient_multiClientConnectionAttempts(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				merr := &multierror.Error{Errors: []error{
-					errors.New("some error"),
-					errors.New("some error"),
-				}, ErrorFormat: singleLineFormatFunc}
-
-				return assert.EqualError(t, err, merr.Error())
-			},
 		},
 	}
 
@@ -241,8 +223,6 @@ func TestClient_multiClientConnectionAttempts(t *testing.T) {
 			newClientFunc.Store(func(o *mqtt.ClientOptions) mqtt.Client { return tt.newClientFunc(t, o) })
 
 			got := c.multipleClients(tt.addrs)
-
-			tt.wantErr(t, err)
 
 			for _, mc := range got {
 				mc.(*mockClient).AssertExpectations(t)

--- a/client_resolver_test.go
+++ b/client_resolver_test.go
@@ -547,7 +547,7 @@ func TestClient_AddressUpdates(t *testing.T) {
 		doneCh := make(chan struct{})
 		r.On("Done").Return(doneCh)
 
-		c, err := NewClient(WithResolver(r), UseMultiConnectionMode)
+		c, err := NewClient(WithResolver(r), UseMultiConnectionMode, ConnectRetryInterval(2*time.Second))
 		assert.NoError(t, err)
 
 		newClientFunc.Store(func(o *mqtt.ClientOptions) mqtt.Client {
@@ -652,7 +652,7 @@ func TestClient_AddressUpdates(t *testing.T) {
 		doneCh := make(chan struct{})
 		r.On("Done").Return(doneCh)
 
-		c, err := NewClient(WithResolver(r), UseMultiConnectionMode)
+		c, err := NewClient(WithResolver(r), UseMultiConnectionMode, ConnectRetryInterval(2*time.Second))
 		assert.NoError(t, err)
 
 		subCallCh := make(chan string, 4)

--- a/client_test.go
+++ b/client_test.go
@@ -479,3 +479,9 @@ func Test_formatAddressWithProtocol(t *testing.T) {
 		})
 	}
 }
+
+func matchErr(want error) any {
+	return mock.MatchedBy(func(err error) bool {
+		return err.Error() == want.Error()
+	})
+}

--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -68,6 +68,7 @@ Package courier contains the client that can be used to interact with the courie
   - [func NewMessageWithDecoder\(payloadDecoder Decoder\) \*Message](#NewMessageWithDecoder)
   - [func \(m \*Message\) DecodePayload\(v interface\{\}\) error](#Message.DecodePayload)
 - [type MessageHandler](#MessageHandler)
+- [type MultiConnectRetryInterval](#MultiConnectRetryInterval)
 - [type OnConnectHandler](#OnConnectHandler)
 - [type OnConnectionLostHandler](#OnConnectionLostHandler)
 - [type OnReconnectHandler](#OnReconnectHandler)
@@ -515,7 +516,7 @@ func WithPersistence(store Store) ClientOption
 WithPersistence allows to configure the store to be used by broker Default persistence is in\-memory persistence with mqtt.MemoryStore
 
 <a name="WithResolver"></a>
-### func [WithResolver](https://github.com/gojek/courier-go/blob/main/client_resolver.go#L35)
+### func [WithResolver](https://github.com/gojek/courier-go/blob/main/client_resolver.go#L36)
 
 ```go
 func WithResolver(resolver Resolver) ClientOption
@@ -729,6 +730,15 @@ MessageHandler is the type that all callbacks being passed to Subscriber must sa
 type MessageHandler func(context.Context, PubSub, *Message)
 ```
 
+<a name="MultiConnectRetryInterval"></a>
+## type [MultiConnectRetryInterval](https://github.com/gojek/courier-go/blob/main/client_options.go#L217)
+
+MultiConnectRetryInterval allows to configure the interval between connection retries. It should be used with UseMultiConnectionMode. Default value is 10 seconds.
+
+```go
+type MultiConnectRetryInterval time.Duration
+```
+
 <a name="OnConnectHandler"></a>
 ## type [OnConnectHandler](https://github.com/gojek/courier-go/blob/main/types.go#L10)
 
@@ -852,7 +862,7 @@ const (
 ```
 
 <a name="Resolver"></a>
-## type [Resolver](https://github.com/gojek/courier-go/blob/main/client_resolver.go#L27-L32)
+## type [Resolver](https://github.com/gojek/courier-go/blob/main/client_resolver.go#L28-L33)
 
 Resolver sends TCPAddress updates on channel returned by UpdateChan\(\) channel.
 
@@ -875,7 +885,7 @@ type Retained bool
 ```
 
 <a name="SharedSubscriptionPredicate"></a>
-## type [SharedSubscriptionPredicate](https://github.com/gojek/courier-go/blob/main/client_options.go#L216)
+## type [SharedSubscriptionPredicate](https://github.com/gojek/courier-go/blob/main/client_options.go#L226)
 
 SharedSubscriptionPredicate allows to configure the predicate function that determines whether a topic is a shared subscription topic.
 
@@ -1002,7 +1012,7 @@ func (smw SubscriberMiddlewareFunc) Middleware(subscriber Subscriber) Subscriber
 Middleware allows SubscriberMiddlewareFunc to implement the subscribeMiddleware interface.
 
 <a name="TCPAddress"></a>
-## type [TCPAddress](https://github.com/gojek/courier-go/blob/main/client_resolver.go#L19-L22)
+## type [TCPAddress](https://github.com/gojek/courier-go/blob/main/client_resolver.go#L20-L23)
 
 TCPAddress specifies Host and Port for remote broker
 
@@ -1014,7 +1024,7 @@ type TCPAddress struct {
 ```
 
 <a name="TCPAddress.String"></a>
-### func \(TCPAddress\) [String](https://github.com/gojek/courier-go/blob/main/client_resolver.go#L24)
+### func \(TCPAddress\) [String](https://github.com/gojek/courier-go/blob/main/client_resolver.go#L25)
 
 ```go
 func (t TCPAddress) String() string

--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -53,6 +53,7 @@ Package courier contains the client that can be used to interact with the courie
   - [func WithUseBase64Decoder\(\) ClientOption](#WithUseBase64Decoder)
   - [func WithUsername\(username string\) ClientOption](#WithUsername)
   - [func WithWriteTimeout\(duration time.Duration\) ClientOption](#WithWriteTimeout)
+- [type ConnectRetryInterval](#ConnectRetryInterval)
 - [type ConnectionInformer](#ConnectionInformer)
 - [type Credential](#Credential)
 - [type CredentialFetcher](#CredentialFetcher)
@@ -68,7 +69,6 @@ Package courier contains the client that can be used to interact with the courie
   - [func NewMessageWithDecoder\(payloadDecoder Decoder\) \*Message](#NewMessageWithDecoder)
   - [func \(m \*Message\) DecodePayload\(v interface\{\}\) error](#Message.DecodePayload)
 - [type MessageHandler](#MessageHandler)
-- [type MultiConnectRetryInterval](#MultiConnectRetryInterval)
 - [type OnConnectHandler](#OnConnectHandler)
 - [type OnConnectionLostHandler](#OnConnectionLostHandler)
 - [type OnReconnectHandler](#OnReconnectHandler)
@@ -571,6 +571,15 @@ func WithWriteTimeout(duration time.Duration) ClientOption
 
 WithWriteTimeout limits how long the client will wait when trying to publish, subscribe or unsubscribe on topic when a context deadline is not set while calling Publisher.Publish, Subscriber.Subscribe, Subscriber.SubscribeMultiple or Unsubscriber.Unsubscribe.
 
+<a name="ConnectRetryInterval"></a>
+## type [ConnectRetryInterval](https://github.com/gojek/courier-go/blob/main/client_options.go#L216)
+
+ConnectRetryInterval allows to configure the interval between connection retries. Default value is 10 seconds.
+
+```go
+type ConnectRetryInterval time.Duration
+```
+
 <a name="ConnectionInformer"></a>
 ## type [ConnectionInformer](https://github.com/gojek/courier-go/blob/main/interface.go#L13-L16)
 
@@ -730,15 +739,6 @@ MessageHandler is the type that all callbacks being passed to Subscriber must sa
 type MessageHandler func(context.Context, PubSub, *Message)
 ```
 
-<a name="MultiConnectRetryInterval"></a>
-## type [MultiConnectRetryInterval](https://github.com/gojek/courier-go/blob/main/client_options.go#L217)
-
-MultiConnectRetryInterval allows to configure the interval between connection retries. It should be used with UseMultiConnectionMode. Default value is 10 seconds.
-
-```go
-type MultiConnectRetryInterval time.Duration
-```
-
 <a name="OnConnectHandler"></a>
 ## type [OnConnectHandler](https://github.com/gojek/courier-go/blob/main/types.go#L10)
 
@@ -885,7 +885,7 @@ type Retained bool
 ```
 
 <a name="SharedSubscriptionPredicate"></a>
-## type [SharedSubscriptionPredicate](https://github.com/gojek/courier-go/blob/main/client_options.go#L226)
+## type [SharedSubscriptionPredicate](https://github.com/gojek/courier-go/blob/main/client_options.go#L225)
 
 SharedSubscriptionPredicate allows to configure the predicate function that determines whether a topic is a shared subscription topic.
 


### PR DESCRIPTION
- Handle multiConnRevision edge cases
    - Only bump if at least on client connects, keep retrial on the rest
    - Skip version bump and disconnect all in case no clients connect at all
- Update stored clients iff newClients are non-empty