### PR TITLE
De-duplicate subscription calls

### DIFF
--- a/client.go
+++ b/client.go
@@ -122,11 +122,21 @@ func (c *Client) Run(ctx context.Context) error {
 }
 
 func (c *Client) stop() error {
-	return c.execute(func(cc mqtt.Client) error {
+	err := c.execute(func(cc mqtt.Client) error {
 		cc.Disconnect(uint(c.options.gracefulShutdownPeriod / time.Millisecond))
 
 		return nil
 	}, execAll)
+
+	if err == nil {
+		c.clientMu.Lock()
+		defer c.clientMu.Unlock()
+
+		c.mqttClient = nil
+		c.mqttClients = nil
+	}
+
+	return err
 }
 
 func (c *Client) handleToken(ctx context.Context, t mqtt.Token, timeoutErr error) error {
@@ -202,6 +212,19 @@ func (c *Client) attemptSingleConnection(addrs []TCPAddress) error {
 	return c.resumeSubscriptions()
 }
 
+func (c *Client) removeStoredSubsCalled(cc mqtt.Client) {
+	c.clientMu.RLock()
+	defer c.clientMu.RUnlock()
+
+	for _, v := range c.mqttClients {
+		if v.client == cc {
+			v.mu.Lock()
+			v.subsCalled.Delete(v.subsCalled.Values()...)
+			v.mu.Unlock()
+		}
+	}
+}
+
 func toClientOptions(c *Client, o *clientOptions, idSuffix string) *mqtt.ClientOptions {
 	opts := mqtt.NewClientOptions()
 
@@ -228,7 +251,7 @@ func toClientOptions(c *Client, o *clientOptions, idSuffix string) *mqtt.ClientO
 		SetConnectTimeout(o.connectTimeout).
 		SetMaxReconnectInterval(o.maxReconnectInterval).
 		SetReconnectingHandler(reconnectHandler(c, o)).
-		SetConnectionLostHandler(connectionLostHandler(o)).
+		SetConnectionLostHandler(connectionLostHandler(c, o)).
 		SetOnConnectHandler(onConnectHandler(c, o))
 
 	return opts
@@ -271,10 +294,7 @@ func formatAddressWithProtocol(opts *clientOptions) string {
 func reconnectHandler(client PubSub, o *clientOptions) mqtt.ReconnectHandler {
 	return func(_ mqtt.Client, opts *mqtt.ClientOptions) {
 		if o.logger != nil {
-			o.logger.Info(context.Background(), "reconnecting", map[string]any{
-				"message":   "reconnecting",
-				"client_id": opts.ClientID,
-			})
+			o.logger.Info(context.Background(), "reconnecting", map[string]any{"client_id": opts.ClientID})
 		}
 
 		if o.onReconnectHandler != nil {
@@ -283,7 +303,7 @@ func reconnectHandler(client PubSub, o *clientOptions) mqtt.ReconnectHandler {
 	}
 }
 
-func connectionLostHandler(o *clientOptions) mqtt.ConnectionLostHandler {
+func connectionLostHandler(c *Client, o *clientOptions) mqtt.ConnectionLostHandler {
 	return func(cc mqtt.Client, err error) {
 		if o.logger != nil {
 			o.logger.Error(context.Background(), err, map[string]any{
@@ -291,6 +311,8 @@ func connectionLostHandler(o *clientOptions) mqtt.ConnectionLostHandler {
 				"client_id": clientIDMapper(cc),
 			})
 		}
+
+		c.removeStoredSubsCalled(cc)
 
 		if o.onConnectionLostHandler != nil {
 			o.onConnectionLostHandler(err)

--- a/client.go
+++ b/client.go
@@ -301,9 +301,6 @@ func connectionLostHandler(o *clientOptions) mqtt.ConnectionLostHandler {
 func onConnectHandler(client *Client, o *clientOptions) mqtt.OnConnectHandler {
 	return func(_ mqtt.Client) {
 		if o.onConnectHandler != nil {
-			client.clientMu.RLock()
-			defer client.clientMu.RUnlock()
-
 			o.onConnectHandler(client)
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -298,9 +298,12 @@ func connectionLostHandler(o *clientOptions) mqtt.ConnectionLostHandler {
 	}
 }
 
-func onConnectHandler(client PubSub, o *clientOptions) mqtt.OnConnectHandler {
+func onConnectHandler(client *Client, o *clientOptions) mqtt.OnConnectHandler {
 	return func(_ mqtt.Client) {
 		if o.onConnectHandler != nil {
+			client.clientMu.RLock()
+			defer client.clientMu.RUnlock()
+
 			o.onConnectHandler(client)
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -219,6 +219,7 @@ func toClientOptions(c *Client, o *clientOptions, idSuffix string) *mqtt.ClientO
 	}
 
 	opts.AddBroker(formatAddressWithProtocol(o)).
+		SetResumeSubs(o.resumeSubscriptions).
 		SetTLSConfig(o.tlsConfig).
 		SetAutoReconnect(o.autoReconnect).
 		SetCleanSession(o.cleanSession).

--- a/client.go
+++ b/client.go
@@ -285,10 +285,9 @@ func reconnectHandler(client PubSub, o *clientOptions) mqtt.ReconnectHandler {
 func connectionLostHandler(o *clientOptions) mqtt.ConnectionLostHandler {
 	return func(cc mqtt.Client, err error) {
 		if o.logger != nil {
-			or := cc.OptionsReader()
 			o.logger.Error(context.Background(), err, map[string]any{
 				"message":   "connection lost",
-				"client_id": or.ClientID(),
+				"client_id": clientIDMapper(cc),
 			})
 		}
 

--- a/client.go
+++ b/client.go
@@ -24,7 +24,7 @@ type Client struct {
 
 	subscriptions map[string]*subscriptionMeta
 	mqttClient    mqtt.Client
-	mqttClients   map[string]mqtt.Client
+	mqttClients   map[string]*internalState
 
 	publisher     Publisher
 	subscriber    Subscriber

--- a/client.go
+++ b/client.go
@@ -299,8 +299,12 @@ func connectionLostHandler(o *clientOptions) mqtt.ConnectionLostHandler {
 }
 
 func onConnectHandler(client *Client, o *clientOptions) mqtt.OnConnectHandler {
-	return func(_ mqtt.Client) {
+	return func(cc mqtt.Client) {
 		if o.onConnectHandler != nil {
+			client.options.logger.Info(context.Background(), "onConnectHandler", map[string]any{
+				"client_id": clientIDMapper(cc),
+			})
+
 			o.onConnectHandler(client)
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -298,13 +298,9 @@ func connectionLostHandler(o *clientOptions) mqtt.ConnectionLostHandler {
 	}
 }
 
-func onConnectHandler(client *Client, o *clientOptions) mqtt.OnConnectHandler {
-	return func(cc mqtt.Client) {
+func onConnectHandler(client PubSub, o *clientOptions) mqtt.OnConnectHandler {
+	return func(_ mqtt.Client) {
 		if o.onConnectHandler != nil {
-			client.options.logger.Info(context.Background(), "onConnectHandler", map[string]any{
-				"client_id": clientIDMapper(cc),
-			})
-
 			o.onConnectHandler(client)
 		}
 	}

--- a/client_options.go
+++ b/client_options.go
@@ -232,9 +232,17 @@ func (ssp SharedSubscriptionPredicate) apply(o *clientOptions) { o.sharedSubscri
 // to subscribe on the same application.
 var UseMultiConnectionMode = multiConnMode{}
 
+// ResumeSubscriptions allows resuming of stored (un)subscribe messages when connecting
+// but not reconnecting if CleanSession is false. Otherwise, these messages are discarded.
+var ResumeSubscriptions = resumeSubscriptions{}
+
 type multiConnMode struct{}
 
 func (mcm multiConnMode) apply(o *clientOptions) { o.multiConnectionMode = true }
+
+type resumeSubscriptions struct{}
+
+func (rs resumeSubscriptions) apply(o *clientOptions) { o.resumeSubscriptions = true }
 
 type clientOptions struct {
 	username, clientID, password,
@@ -244,7 +252,8 @@ type clientOptions struct {
 
 	tlsConfig *tls.Config
 
-	autoReconnect, maintainOrder, cleanSession, multiConnectionMode bool
+	autoReconnect, maintainOrder, cleanSession,
+	multiConnectionMode, resumeSubscriptions bool
 
 	connectTimeout, writeTimeout, keepAlive,
 	maxReconnectInterval, gracefulShutdownPeriod,

--- a/client_options_test.go
+++ b/client_options_test.go
@@ -123,6 +123,11 @@ func (s *ClientOptionSuite) Test_apply() {
 			option: UseMultiConnectionMode,
 			want:   &clientOptions{multiConnectionMode: true},
 		},
+		{
+			name:   "ResumeSubscriptions",
+			option: ResumeSubscriptions,
+			want:   &clientOptions{resumeSubscriptions: true},
+		},
 	}
 
 	for _, t := range tests {

--- a/client_resolver.go
+++ b/client_resolver.go
@@ -85,6 +85,9 @@ func (c *Client) resumeSubscriptions() error {
 }
 
 func (c *Client) reloadClients(clients map[string]mqtt.Client) {
+	c.clientMu.Lock()
+	defer c.clientMu.Unlock()
+
 	oldClients := xmap.Values(c.mqttClients)
 
 	if len(clients) > 0 {

--- a/client_resolver.go
+++ b/client_resolver.go
@@ -12,7 +12,6 @@ import (
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/hashicorp/go-multierror"
 
-	"github.com/gojekfarm/xtools/generic"
 	"github.com/gojekfarm/xtools/generic/slice"
 	"github.com/gojekfarm/xtools/generic/xmap"
 )
@@ -92,7 +91,7 @@ func (c *Client) reloadClients(clients map[string]mqtt.Client) {
 	if len(clients) > 0 {
 		ncs := make(map[string]*internalState, len(clients))
 		for k, cc := range clients {
-			ncs[k] = &internalState{client: cc, subsCalled: generic.NewSet[string]()}
+			ncs[k] = &internalState{client: cc}
 		}
 		c.mqttClients = ncs
 	}

--- a/client_resolver.go
+++ b/client_resolver.go
@@ -85,9 +85,6 @@ func (c *Client) resumeSubscriptions() error {
 }
 
 func (c *Client) reloadClients(clients map[string]mqtt.Client) {
-	c.clientMu.Lock()
-	defer c.clientMu.Unlock()
-
 	oldClients := xmap.Values(c.mqttClients)
 
 	if len(clients) > 0 {

--- a/client_resolver.go
+++ b/client_resolver.go
@@ -134,7 +134,6 @@ func (c *Client) multipleClients(addrs []TCPAddress) map[string]mqtt.Client {
 	clients := &sync.Map{}
 	currRev := c.multiConnRevision.Load()
 
-	currRev := c.multiConnRevision.Load()
 	c.options.logger.Info(context.Background(), "attempting multiple connections", map[string]any{
 		"multiConnRevision": currRev,
 	})
@@ -178,10 +177,6 @@ func (c *Client) multipleClients(addrs []TCPAddress) map[string]mqtt.Client {
 	anyConnected := false
 
 	clients.Range(func(key, value interface{}) bool {
-		cc := value.(mqtt.Client)
-		if cc.IsConnectionOpen() {
-			anyConnected = true
-		}
 		// nolint: errcheck
 		cc := value.(mqtt.Client)
 

--- a/client_resolver.go
+++ b/client_resolver.go
@@ -91,9 +91,11 @@ func (c *Client) reloadClients(clients map[string]mqtt.Client) {
 
 	if len(clients) > 0 {
 		ncs := make(map[string]*internalState, len(clients))
+
 		for k, cc := range clients {
 			ncs[k] = &internalState{client: cc, subsCalled: generic.NewSet[string]()}
 		}
+
 		c.mqttClients = ncs
 	}
 

--- a/client_resolver.go
+++ b/client_resolver.go
@@ -128,6 +128,11 @@ func (c *Client) multipleClients(addrs []TCPAddress) map[string]mqtt.Client {
 	clients := &sync.Map{}
 	currRev := c.multiConnRevision.Load()
 
+	currRev := c.multiConnRevision.Load()
+	c.options.logger.Info(context.Background(), "attempting multiple connections", map[string]any{
+		"multiConnRevision": currRev,
+	})
+
 	i := &atomicCounter{}
 	iaddrs := slice.Map(addrs, func(a TCPAddress) indexAddress { return indexAddress{index: int(i.next()), addr: a} })
 
@@ -167,6 +172,10 @@ func (c *Client) multipleClients(addrs []TCPAddress) map[string]mqtt.Client {
 	anyConnected := false
 
 	clients.Range(func(key, value interface{}) bool {
+		cc := value.(mqtt.Client)
+		if cc.IsConnectionOpen() {
+			anyConnected = true
+		}
 		// nolint: errcheck
 		cc := value.(mqtt.Client)
 

--- a/client_resolver.go
+++ b/client_resolver.go
@@ -282,6 +282,10 @@ func singleLineFormatFunc(es []error) string {
 }
 
 func clientIDMapper(cc mqtt.Client) string {
+	if cc == nil {
+		return "<nil-client>"
+	}
+
 	r := cc.OptionsReader()
 
 	if reflect.ValueOf(r).FieldByName("options").IsNil() {

--- a/client_resolver.go
+++ b/client_resolver.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/gojekfarm/xtools/generic"
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/gojekfarm/xtools/generic/slice"
@@ -91,7 +92,7 @@ func (c *Client) reloadClients(clients map[string]mqtt.Client) {
 	if len(clients) > 0 {
 		ncs := make(map[string]*internalState, len(clients))
 		for k, cc := range clients {
-			ncs[k] = &internalState{client: cc}
+			ncs[k] = &internalState{client: cc, subsCalled: generic.NewSet[string]()}
 		}
 		c.mqttClients = ncs
 	}

--- a/client_resolver.go
+++ b/client_resolver.go
@@ -134,10 +134,6 @@ func (c *Client) multipleClients(addrs []TCPAddress) map[string]mqtt.Client {
 	clients := &sync.Map{}
 	currRev := c.multiConnRevision.Load()
 
-	c.options.logger.Info(context.Background(), "attempting multiple connections", map[string]any{
-		"multiConnRevision": currRev,
-	})
-
 	i := &atomicCounter{}
 	iaddrs := slice.Map(addrs, func(a TCPAddress) indexAddress { return indexAddress{index: int(i.next()), addr: a} })
 

--- a/client_resolver.go
+++ b/client_resolver.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
-	"github.com/gojekfarm/xtools/generic"
 	"github.com/hashicorp/go-multierror"
 
+	"github.com/gojekfarm/xtools/generic"
 	"github.com/gojekfarm/xtools/generic/slice"
 	"github.com/gojekfarm/xtools/generic/xmap"
 )

--- a/client_resolver.go
+++ b/client_resolver.go
@@ -12,6 +12,7 @@ import (
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/hashicorp/go-multierror"
 
+	"github.com/gojekfarm/xtools/generic"
 	"github.com/gojekfarm/xtools/generic/slice"
 	"github.com/gojekfarm/xtools/generic/xmap"
 )

--- a/client_resolver_test.go
+++ b/client_resolver_test.go
@@ -823,6 +823,10 @@ func Test_clientIDMapper(t *testing.T) {
 		want string
 	}{
 		{
+			name: "nil_client",
+			want: "<nil-client>",
+		},
+		{
 			name: "nil_options",
 			cc:   &mockClient{},
 			want: "<nil-options>",

--- a/client_subscribe.go
+++ b/client_subscribe.go
@@ -8,7 +8,6 @@ import (
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 
-	"github.com/gojekfarm/xtools/generic"
 	"github.com/gojekfarm/xtools/generic/slice"
 )
 
@@ -163,24 +162,18 @@ func callbackWrapper(c *Client, callback MessageHandler) mqtt.MessageHandler {
 }
 
 type internalState struct {
-	subsCalled generic.Set[string]
-	client     mqtt.Client
-
-	mu sync.RWMutex
+	client  mqtt.Client
+	subsMap sync.Map
 }
 
 func (s *internalState) topicSubscribed(topic string) bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	_, ok := s.subsMap.Load(topic)
 
-	return s.subsCalled.Has(topic)
+	return ok
 }
 
 func (s *internalState) addTopic(topic string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.subsCalled.Add(topic)
+	s.subsMap.Store(topic, struct{}{})
 }
 
 func filterSubs(

--- a/client_subscribe.go
+++ b/client_subscribe.go
@@ -3,11 +3,9 @@ package courier
 import (
 	"bytes"
 	"context"
-	"sync"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 
-	"github.com/gojekfarm/xtools/generic"
 	"github.com/gojekfarm/xtools/generic/slice"
 )
 
@@ -155,12 +153,6 @@ func subscribeOnlyOnce(topic string) execOptWithState {
 
 		return err
 	}
-}
-
-type internalState struct {
-	subsCalled generic.Set[string]
-	client     mqtt.Client
-	mu         sync.Mutex
 }
 
 func filterSubs(

--- a/client_subscribe.go
+++ b/client_subscribe.go
@@ -3,6 +3,7 @@ package courier
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"sync"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
@@ -79,6 +80,8 @@ func subscriberFuncs(c *Client) Subscriber {
 		func(ctx context.Context, topic string, callback MessageHandler, opts ...Option) error {
 			o := composeOptions(opts)
 
+			c.options.logger.Info(context.Background(), "subscribeFuncs", map[string]any{})
+
 			var eo execOpt = execOneRandom
 			if c.options.sharedSubscriptionPredicate(topic) {
 				eo = &execOptFn{
@@ -97,6 +100,8 @@ func subscriberFuncs(c *Client) Subscriber {
 					},
 				}
 			}
+
+			c.options.logger.Info(context.Background(), fmt.Sprintf("eo: %T", eo), map[string]any{})
 
 			return c.execute(func(cc mqtt.Client) error {
 				or := cc.OptionsReader()

--- a/client_subscribe.go
+++ b/client_subscribe.go
@@ -104,10 +104,8 @@ func subscriberFuncs(c *Client) Subscriber {
 			c.options.logger.Info(context.Background(), fmt.Sprintf("eo: %T", eo), map[string]any{})
 
 			return c.execute(func(cc mqtt.Client) error {
-				or := cc.OptionsReader()
-
 				c.options.logger.Info(context.Background(), "subscribing", map[string]any{
-					"clientId": or.ClientID(),
+					"clientId": clientIDMapper(cc),
 				})
 
 				return c.handleToken(ctx, cc.Subscribe(topic, o.qos, callbackWrapper(c, callback)), ErrSubscribeTimeout)

--- a/client_subscribe.go
+++ b/client_subscribe.go
@@ -83,6 +83,12 @@ func subscriberFuncs(c *Client) Subscriber {
 			}
 
 			return c.execute(func(cc mqtt.Client) error {
+				or := cc.OptionsReader()
+
+				c.options.logger.Info(context.Background(), "subscribing", map[string]any{
+					"clientId": or.ClientID(),
+				})
+
 				return c.handleToken(ctx, cc.Subscribe(topic, o.qos, callbackWrapper(c, callback)), ErrSubscribeTimeout)
 			}, eo)
 		},

--- a/client_subscribe.go
+++ b/client_subscribe.go
@@ -105,6 +105,7 @@ func subscriberFuncs(c *Client) Subscriber {
 			return c.execute(func(cc mqtt.Client) error {
 				c.options.logger.Info(context.Background(), "subscribing", map[string]any{
 					"clientId": clientIDMapper(cc),
+					"flow":     "subscribeFunc",
 				})
 
 				return c.handleToken(ctx, cc.Subscribe(topic, o.qos, callbackWrapper(c, callback)), ErrSubscribeTimeout)

--- a/client_subscribe.go
+++ b/client_subscribe.go
@@ -3,11 +3,11 @@ package courier
 import (
 	"bytes"
 	"context"
-	"github.com/gojekfarm/xtools/generic"
 	"sync"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 
+	"github.com/gojekfarm/xtools/generic"
 	"github.com/gojekfarm/xtools/generic/slice"
 )
 

--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -280,7 +280,7 @@ func (c *Client) Stop()
 Stop will disconnect from the broker and finish up any pending work on internal communication workers. This can only block until the period configured with the ClientOption WithGracefulShutdownPeriod.
 
 <a name="Client.Subscribe"></a>
-### func \(\*Client\) [Subscribe](https://github.com/gojek/courier-go/blob/main/client_subscribe.go#L15)
+### func \(\*Client\) [Subscribe](https://github.com/gojek/courier-go/blob/main/client_subscribe.go#L13)
 
 ```go
 func (c *Client) Subscribe(ctx context.Context, topic string, callback MessageHandler, opts ...Option) error
@@ -289,7 +289,7 @@ func (c *Client) Subscribe(ctx context.Context, topic string, callback MessageHa
 Subscribe allows to subscribe to messages from an MQTT broker
 
 <a name="Client.SubscribeMultiple"></a>
-### func \(\*Client\) [SubscribeMultiple](https://github.com/gojek/courier-go/blob/main/client_subscribe.go#L32-L36)
+### func \(\*Client\) [SubscribeMultiple](https://github.com/gojek/courier-go/blob/main/client_subscribe.go#L30-L34)
 
 ```go
 func (c *Client) SubscribeMultiple(ctx context.Context, topicsWithQos map[string]QOSLevel, callback MessageHandler) error
@@ -316,7 +316,7 @@ func (c *Client) UsePublisherMiddleware(mwf ...PublisherMiddlewareFunc)
 UsePublisherMiddleware appends a PublisherMiddlewareFunc to the chain. Middleware can be used to intercept or otherwise modify, process or skip messages. They are executed in the order that they are applied to the Client.
 
 <a name="Client.UseSubscriberMiddleware"></a>
-### func \(\*Client\) [UseSubscriberMiddleware](https://github.com/gojek/courier-go/blob/main/client_subscribe.go#L59)
+### func \(\*Client\) [UseSubscriberMiddleware](https://github.com/gojek/courier-go/blob/main/client_subscribe.go#L57)
 
 ```go
 func (c *Client) UseSubscriberMiddleware(mwf ...SubscriberMiddlewareFunc)

--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -280,7 +280,7 @@ func (c *Client) Stop()
 Stop will disconnect from the broker and finish up any pending work on internal communication workers. This can only block until the period configured with the ClientOption WithGracefulShutdownPeriod.
 
 <a name="Client.Subscribe"></a>
-### func \(\*Client\) [Subscribe](https://github.com/gojek/courier-go/blob/main/client_subscribe.go#L13)
+### func \(\*Client\) [Subscribe](https://github.com/gojek/courier-go/blob/main/client_subscribe.go#L15)
 
 ```go
 func (c *Client) Subscribe(ctx context.Context, topic string, callback MessageHandler, opts ...Option) error
@@ -289,7 +289,7 @@ func (c *Client) Subscribe(ctx context.Context, topic string, callback MessageHa
 Subscribe allows to subscribe to messages from an MQTT broker
 
 <a name="Client.SubscribeMultiple"></a>
-### func \(\*Client\) [SubscribeMultiple](https://github.com/gojek/courier-go/blob/main/client_subscribe.go#L30-L34)
+### func \(\*Client\) [SubscribeMultiple](https://github.com/gojek/courier-go/blob/main/client_subscribe.go#L32-L36)
 
 ```go
 func (c *Client) SubscribeMultiple(ctx context.Context, topicsWithQos map[string]QOSLevel, callback MessageHandler) error
@@ -316,7 +316,7 @@ func (c *Client) UsePublisherMiddleware(mwf ...PublisherMiddlewareFunc)
 UsePublisherMiddleware appends a PublisherMiddlewareFunc to the chain. Middleware can be used to intercept or otherwise modify, process or skip messages. They are executed in the order that they are applied to the Client.
 
 <a name="Client.UseSubscriberMiddleware"></a>
-### func \(\*Client\) [UseSubscriberMiddleware](https://github.com/gojek/courier-go/blob/main/client_subscribe.go#L57)
+### func \(\*Client\) [UseSubscriberMiddleware](https://github.com/gojek/courier-go/blob/main/client_subscribe.go#L59)
 
 ```go
 func (c *Client) UseSubscriberMiddleware(mwf ...SubscriberMiddlewareFunc)
@@ -516,7 +516,7 @@ func WithPersistence(store Store) ClientOption
 WithPersistence allows to configure the store to be used by broker Default persistence is in\-memory persistence with mqtt.MemoryStore
 
 <a name="WithResolver"></a>
-### func [WithResolver](https://github.com/gojek/courier-go/blob/main/client_resolver.go#L36)
+### func [WithResolver](https://github.com/gojek/courier-go/blob/main/client_resolver.go#L37)
 
 ```go
 func WithResolver(resolver Resolver) ClientOption
@@ -862,7 +862,7 @@ const (
 ```
 
 <a name="Resolver"></a>
-## type [Resolver](https://github.com/gojek/courier-go/blob/main/client_resolver.go#L28-L33)
+## type [Resolver](https://github.com/gojek/courier-go/blob/main/client_resolver.go#L29-L34)
 
 Resolver sends TCPAddress updates on channel returned by UpdateChan\(\) channel.
 
@@ -1012,7 +1012,7 @@ func (smw SubscriberMiddlewareFunc) Middleware(subscriber Subscriber) Subscriber
 Middleware allows SubscriberMiddlewareFunc to implement the subscribeMiddleware interface.
 
 <a name="TCPAddress"></a>
-## type [TCPAddress](https://github.com/gojek/courier-go/blob/main/client_resolver.go#L20-L23)
+## type [TCPAddress](https://github.com/gojek/courier-go/blob/main/client_resolver.go#L21-L24)
 
 TCPAddress specifies Host and Port for remote broker
 
@@ -1024,7 +1024,7 @@ type TCPAddress struct {
 ```
 
 <a name="TCPAddress.String"></a>
-### func \(TCPAddress\) [String](https://github.com/gojek/courier-go/blob/main/client_resolver.go#L25)
+### func \(TCPAddress\) [String](https://github.com/gojek/courier-go/blob/main/client_resolver.go#L26)
 
 ```go
 func (t TCPAddress) String() string

--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -129,6 +129,12 @@ var (
 var ErrClientNotInitialized = errors.New("courier: client not initialized")
 ```
 
+<a name="ResumeSubscriptions"></a>ResumeSubscriptions allows resuming of stored \(un\)subscribe messages when connecting but not reconnecting if CleanSession is false. Otherwise, these messages are discarded.
+
+```go
+var ResumeSubscriptions = resumeSubscriptions{}
+```
+
 <a name="UseMultiConnectionMode"></a>UseMultiConnectionMode allows to configure the client to use multiple connections when available.
 
 This is useful when working with shared subscriptions and multiple connections can be created to subscribe on the same application.

--- a/exec.go
+++ b/exec.go
@@ -60,7 +60,7 @@ func (c *Client) execute(f func(mqtt.Client) error, eo execOpt) error {
 func (c *Client) filterStates(predicate func(*internalState) bool) []*internalState {
 	return slice.Filter(
 		xmap.Values(c.mqttClients),
-		func(is *internalState) bool { return predicate(is) },
+		predicate,
 	)
 }
 

--- a/exec.go
+++ b/exec.go
@@ -1,6 +1,7 @@
 package courier
 
 import (
+	"context"
 	"math/rand"
 	"sync/atomic"
 
@@ -89,6 +90,11 @@ func (c *Client) execMultiConn(f func(mqtt.Client) error, eo execOpt) error {
 		}), accumulateErrors)
 	case *execOptFn:
 		return slice.Reduce(slice.MapConcurrent(c.filterStates(eo.predicate), func(is *internalState) error {
+			c.options.logger.Info(context.Background(), "executing", map[string]any{
+				"clientId": clientIDMapper(is.client),
+				"flow":     "execute",
+			})
+
 			err := f(is.client)
 			eo.onExec(is, err)
 			return err

--- a/exec.go
+++ b/exec.go
@@ -3,15 +3,23 @@ package courier
 import (
 	"errors"
 	"math/rand"
+	"sync"
 	"sync/atomic"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 
+	"github.com/gojekfarm/xtools/generic"
 	"github.com/gojekfarm/xtools/generic/slice"
 	"github.com/gojekfarm/xtools/generic/xmap"
 )
 
 var errInvalidExecOpt = errors.New("courier: invalid exec option")
+
+type internalState struct {
+	subsCalled generic.Set[string]
+	client     mqtt.Client
+	mu         sync.Mutex
+}
 
 type execOpt interface{ isExecOpt() }
 

--- a/exec_test.go
+++ b/exec_test.go
@@ -1,0 +1,44 @@
+package courier
+
+import (
+	"testing"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptionsImplementInterface(t *testing.T) {
+	testcases := []struct {
+		name string
+		opt  any
+	}{
+		{
+			name: "execOptConst",
+			opt:  execOptConst(0),
+		},
+		{
+			name: "execOptWithState",
+			opt:  execOptWithState(nil),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			eo, ok := tc.opt.(execOpt)
+			if !ok {
+				t.Errorf("expected %T to implement execOpt", tc.opt)
+			}
+			eo.isExecOpt()
+		})
+	}
+}
+
+type invalidExecOpt bool
+
+func (ieo invalidExecOpt) isExecOpt() {}
+
+func TestClient_execMultiConn_invalidExecOption(t *testing.T) {
+	assert.EqualError(t, new(Client).execMultiConn(func(mqtt.Client) error {
+		return nil
+	}, invalidExecOpt(true)), errInvalidExecOpt.Error())
+}


### PR DESCRIPTION
When using Option such as OnConnectHandler, the delegated paho library calls it in a separate goroutine as soon as the connection is open to a broker.

This change makes sure that in case of a shared subscription, actual subscription is called only once per client.