### PR TITLE
feat: support paho logging using courier-go logger

### DIFF
--- a/client.go
+++ b/client.go
@@ -77,6 +77,16 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	c.subscriber = subscriberFuncs(c)
 	c.unsubscriber = unsubscriberHandler(c)
 
+	if c.options.logger != nil {
+		wpl := &pahoLogger{logger: c.options.logger, level: warnLevel}
+		epl := &pahoLogger{logger: c.options.logger, level: errorLevel}
+		dpl := &pahoLogger{logger: c.options.logger, level: debugLevel}
+		mqtt.WARN = wpl
+		mqtt.ERROR = epl
+		mqtt.CRITICAL = epl
+		mqtt.DEBUG = dpl
+	}
+
 	return c, nil
 }
 

--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -77,7 +78,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	c.subscriber = subscriberFuncs(c)
 	c.unsubscriber = unsubscriberHandler(c)
 
-	if c.options.logger != nil && mqtt.WARN == nil {
+	if c.options.logger != nil && reflect.TypeOf(mqtt.WARN) == reflect.TypeOf(mqtt.NOOPLogger{}) {
 		wpl := &pahoLogger{logger: c.options.logger, level: warnLevel}
 		epl := &pahoLogger{logger: c.options.logger, level: errorLevel}
 		dpl := &pahoLogger{logger: c.options.logger, level: debugLevel}

--- a/client.go
+++ b/client.go
@@ -77,7 +77,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	c.subscriber = subscriberFuncs(c)
 	c.unsubscriber = unsubscriberHandler(c)
 
-	if c.options.logger != nil {
+	if c.options.logger != nil && mqtt.WARN == nil {
 		wpl := &pahoLogger{logger: c.options.logger, level: warnLevel}
 		epl := &pahoLogger{logger: c.options.logger, level: errorLevel}
 		dpl := &pahoLogger{logger: c.options.logger, level: debugLevel}

--- a/client.go
+++ b/client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"reflect"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -77,16 +76,6 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	c.publisher = publishHandler(c)
 	c.subscriber = subscriberFuncs(c)
 	c.unsubscriber = unsubscriberHandler(c)
-
-	if c.options.logger != nil && reflect.TypeOf(mqtt.WARN) == reflect.TypeOf(mqtt.NOOPLogger{}) {
-		wpl := &pahoLogger{logger: c.options.logger, level: warnLevel}
-		epl := &pahoLogger{logger: c.options.logger, level: errorLevel}
-		dpl := &pahoLogger{logger: c.options.logger, level: debugLevel}
-		mqtt.WARN = wpl
-		mqtt.ERROR = epl
-		mqtt.CRITICAL = epl
-		mqtt.DEBUG = dpl
-	}
 
 	return c, nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -261,6 +261,11 @@ func TestNewClientWithCredentialFetcher(t *testing.T) {
 		c.Stop()
 
 		mcf.AssertExpectations(t)
+
+		mqtt.CRITICAL = mqtt.NOOPLogger{}
+		mqtt.ERROR = mqtt.NOOPLogger{}
+		mqtt.WARN = mqtt.NOOPLogger{}
+		mqtt.DEBUG = mqtt.NOOPLogger{}
 	})
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -264,6 +264,9 @@ func TestNewClientWithCredentialFetcher(t *testing.T) {
 
 		mcf.AssertExpectations(t)
 
+		// wait for mocked logger calling goroutines to finish
+		time.Sleep(1 * time.Second)
+		// restore paho logger back to default logger
 		mqtt.CRITICAL = mqtt.NOOPLogger{}
 		mqtt.ERROR = mqtt.NOOPLogger{}
 		mqtt.WARN = mqtt.NOOPLogger{}

--- a/client_test.go
+++ b/client_test.go
@@ -258,6 +258,8 @@ func TestNewClientWithCredentialFetcher(t *testing.T) {
 			return ml.AssertExpectations(t)
 		}, 10*time.Second, 250*time.Millisecond)
 
+		commsErr := errors.New("[client]   Connect comms goroutine - error triggered EOF\n")
+		ml.On("Error", mock.Anything, commsErr, nil).Maybe()
 		c.Stop()
 
 		mcf.AssertExpectations(t)

--- a/client_test.go
+++ b/client_test.go
@@ -247,7 +247,6 @@ func TestNewClientWithCredentialFetcher(t *testing.T) {
 		credErr := errors.New("error")
 		mcf.On("Credentials", mock.Anything).Return(nil, credErr)
 		ml.On("Error", mock.Anything, credErr, map[string]any{"message": "failed to fetch credentials"})
-		ml.On("Debug", mock.Anything, mock.Anything, mock.Anything)
 
 		c, err := NewClient(append(defOpts, WithCredentialFetcher(mcf), WithLogger(ml))...)
 		assert.NoError(t, err)

--- a/client_test.go
+++ b/client_test.go
@@ -247,6 +247,7 @@ func TestNewClientWithCredentialFetcher(t *testing.T) {
 		credErr := errors.New("error")
 		mcf.On("Credentials", mock.Anything).Return(nil, credErr)
 		ml.On("Error", mock.Anything, credErr, map[string]any{"message": "failed to fetch credentials"})
+		ml.On("Debug", mock.Anything, mock.Anything, mock.Anything)
 
 		c, err := NewClient(append(defOpts, WithCredentialFetcher(mcf), WithLogger(ml))...)
 		assert.NoError(t, err)

--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -176,7 +176,7 @@ func WaitForConnection(c ConnectionInformer, waitFor time.Duration, tick time.Du
 WaitForConnection checks if the Client is connected, it calls ConnectionInformer.IsConnected after every tick and waitFor is the maximum duration it can block. Returns true only when ConnectionInformer.IsConnected returns true
 
 <a name="Client"></a>
-## type [Client](https://github.com/gojek/courier-go/blob/main/client.go#L22-L43)
+## type [Client](https://github.com/gojek/courier-go/blob/main/client.go#L23-L44)
 
 Client allows to communicate with an MQTT broker
 
@@ -187,7 +187,7 @@ type Client struct {
 ```
 
 <a name="NewClient"></a>
-### func [NewClient](https://github.com/gojek/courier-go/blob/main/client.go#L48)
+### func [NewClient](https://github.com/gojek/courier-go/blob/main/client.go#L49)
 
 ```go
 func NewClient(opts ...ClientOption) (*Client, error)
@@ -255,7 +255,7 @@ func (c *Client) InfoHandler() http.Handler
 InfoHandler returns a http.Handler that exposes the connected clients information
 
 <a name="Client.IsConnected"></a>
-### func \(\*Client\) [IsConnected](https://github.com/gojek/courier-go/blob/main/client.go#L94)
+### func \(\*Client\) [IsConnected](https://github.com/gojek/courier-go/blob/main/client.go#L95)
 
 ```go
 func (c *Client) IsConnected() bool
@@ -273,7 +273,7 @@ func (c *Client) Publish(ctx context.Context, topic string, message interface{},
 Publish allows to publish messages to an MQTT broker
 
 <a name="Client.Run"></a>
-### func \(\*Client\) [Run](https://github.com/gojek/courier-go/blob/main/client.go#L122)
+### func \(\*Client\) [Run](https://github.com/gojek/courier-go/blob/main/client.go#L123)
 
 ```go
 func (c *Client) Run(ctx context.Context) error
@@ -282,7 +282,7 @@ func (c *Client) Run(ctx context.Context) error
 Run will start running the Client. This makes Client compatible with github.com/gojekfarm/xrun package. https://pkg.go.dev/github.com/gojekfarm/xrun
 
 <a name="Client.Start"></a>
-### func \(\*Client\) [Start](https://github.com/gojek/courier-go/blob/main/client.go#L107)
+### func \(\*Client\) [Start](https://github.com/gojek/courier-go/blob/main/client.go#L108)
 
 ```go
 func (c *Client) Start() error
@@ -291,7 +291,7 @@ func (c *Client) Start() error
 Start will attempt to connect to the broker.
 
 <a name="Client.Stop"></a>
-### func \(\*Client\) [Stop](https://github.com/gojek/courier-go/blob/main/client.go#L118)
+### func \(\*Client\) [Stop](https://github.com/gojek/courier-go/blob/main/client.go#L119)
 
 ```go
 func (c *Client) Stop()

--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -255,7 +255,7 @@ func (c *Client) InfoHandler() http.Handler
 InfoHandler returns a http.Handler that exposes the connected clients information
 
 <a name="Client.IsConnected"></a>
-### func \(\*Client\) [IsConnected](https://github.com/gojek/courier-go/blob/main/client.go#L84)
+### func \(\*Client\) [IsConnected](https://github.com/gojek/courier-go/blob/main/client.go#L94)
 
 ```go
 func (c *Client) IsConnected() bool
@@ -273,7 +273,7 @@ func (c *Client) Publish(ctx context.Context, topic string, message interface{},
 Publish allows to publish messages to an MQTT broker
 
 <a name="Client.Run"></a>
-### func \(\*Client\) [Run](https://github.com/gojek/courier-go/blob/main/client.go#L112)
+### func \(\*Client\) [Run](https://github.com/gojek/courier-go/blob/main/client.go#L122)
 
 ```go
 func (c *Client) Run(ctx context.Context) error
@@ -282,7 +282,7 @@ func (c *Client) Run(ctx context.Context) error
 Run will start running the Client. This makes Client compatible with github.com/gojekfarm/xrun package. https://pkg.go.dev/github.com/gojekfarm/xrun
 
 <a name="Client.Start"></a>
-### func \(\*Client\) [Start](https://github.com/gojek/courier-go/blob/main/client.go#L97)
+### func \(\*Client\) [Start](https://github.com/gojek/courier-go/blob/main/client.go#L107)
 
 ```go
 func (c *Client) Start() error
@@ -291,7 +291,7 @@ func (c *Client) Start() error
 Start will attempt to connect to the broker.
 
 <a name="Client.Stop"></a>
-### func \(\*Client\) [Stop](https://github.com/gojek/courier-go/blob/main/client.go#L108)
+### func \(\*Client\) [Stop](https://github.com/gojek/courier-go/blob/main/client.go#L118)
 
 ```go
 func (c *Client) Stop()
@@ -501,7 +501,7 @@ func WithKeepAlive(duration time.Duration) ClientOption
 WithKeepAlive will set the amount of time \(in seconds\) that the client should wait before sending a PING request to the broker. This will allow the client to know that a connection has not been lost with the server. Deprecated: Use KeepAlive instead.
 
 <a name="WithLogger"></a>
-### func [WithLogger](https://github.com/gojek/courier-go/blob/main/log.go#L6)
+### func [WithLogger](https://github.com/gojek/courier-go/blob/main/log.go#L9)
 
 ```go
 func WithLogger(l Logger) ClientOption
@@ -742,14 +742,16 @@ type KeepAlive time.Duration
 ```
 
 <a name="Logger"></a>
-## type [Logger](https://github.com/gojek/courier-go/blob/main/log.go#L9-L12)
+## type [Logger](https://github.com/gojek/courier-go/blob/main/log.go#L12-L17)
 
 Logger is the interface that wraps the Info and Error methods.
 
 ```go
 type Logger interface {
-    Info(ctx context.Context, msg string, attrs map[string]any)
     Error(ctx context.Context, err error, attrs map[string]any)
+    Warn(ctx context.Context, msg string, attrs map[string]any)
+    Info(ctx context.Context, msg string, attrs map[string]any)
+    Debug(ctx context.Context, msg string, attrs map[string]any)
 }
 ```
 

--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -176,7 +176,7 @@ func WaitForConnection(c ConnectionInformer, waitFor time.Duration, tick time.Du
 WaitForConnection checks if the Client is connected, it calls ConnectionInformer.IsConnected after every tick and waitFor is the maximum duration it can block. Returns true only when ConnectionInformer.IsConnected returns true
 
 <a name="Client"></a>
-## type [Client](https://github.com/gojek/courier-go/blob/main/client.go#L23-L44)
+## type [Client](https://github.com/gojek/courier-go/blob/main/client.go#L22-L43)
 
 Client allows to communicate with an MQTT broker
 
@@ -187,7 +187,7 @@ type Client struct {
 ```
 
 <a name="NewClient"></a>
-### func [NewClient](https://github.com/gojek/courier-go/blob/main/client.go#L49)
+### func [NewClient](https://github.com/gojek/courier-go/blob/main/client.go#L48)
 
 ```go
 func NewClient(opts ...ClientOption) (*Client, error)
@@ -255,7 +255,7 @@ func (c *Client) InfoHandler() http.Handler
 InfoHandler returns a http.Handler that exposes the connected clients information
 
 <a name="Client.IsConnected"></a>
-### func \(\*Client\) [IsConnected](https://github.com/gojek/courier-go/blob/main/client.go#L95)
+### func \(\*Client\) [IsConnected](https://github.com/gojek/courier-go/blob/main/client.go#L84)
 
 ```go
 func (c *Client) IsConnected() bool
@@ -273,7 +273,7 @@ func (c *Client) Publish(ctx context.Context, topic string, message interface{},
 Publish allows to publish messages to an MQTT broker
 
 <a name="Client.Run"></a>
-### func \(\*Client\) [Run](https://github.com/gojek/courier-go/blob/main/client.go#L123)
+### func \(\*Client\) [Run](https://github.com/gojek/courier-go/blob/main/client.go#L112)
 
 ```go
 func (c *Client) Run(ctx context.Context) error
@@ -282,7 +282,7 @@ func (c *Client) Run(ctx context.Context) error
 Run will start running the Client. This makes Client compatible with github.com/gojekfarm/xrun package. https://pkg.go.dev/github.com/gojekfarm/xrun
 
 <a name="Client.Start"></a>
-### func \(\*Client\) [Start](https://github.com/gojek/courier-go/blob/main/client.go#L108)
+### func \(\*Client\) [Start](https://github.com/gojek/courier-go/blob/main/client.go#L97)
 
 ```go
 func (c *Client) Start() error
@@ -291,7 +291,7 @@ func (c *Client) Start() error
 Start will attempt to connect to the broker.
 
 <a name="Client.Stop"></a>
-### func \(\*Client\) [Stop](https://github.com/gojek/courier-go/blob/main/client.go#L119)
+### func \(\*Client\) [Stop](https://github.com/gojek/courier-go/blob/main/client.go#L108)
 
 ```go
 func (c *Client) Stop()
@@ -501,7 +501,7 @@ func WithKeepAlive(duration time.Duration) ClientOption
 WithKeepAlive will set the amount of time \(in seconds\) that the client should wait before sending a PING request to the broker. This will allow the client to know that a connection has not been lost with the server. Deprecated: Use KeepAlive instead.
 
 <a name="WithLogger"></a>
-### func [WithLogger](https://github.com/gojek/courier-go/blob/main/log.go#L9)
+### func [WithLogger](https://github.com/gojek/courier-go/blob/main/log.go#L14)
 
 ```go
 func WithLogger(l Logger) ClientOption
@@ -742,7 +742,7 @@ type KeepAlive time.Duration
 ```
 
 <a name="Logger"></a>
-## type [Logger](https://github.com/gojek/courier-go/blob/main/log.go#L12-L17)
+## type [Logger](https://github.com/gojek/courier-go/blob/main/log.go#L23-L28)
 
 Logger is the interface that wraps the Info and Error methods.
 

--- a/log.go
+++ b/log.go
@@ -1,19 +1,61 @@
 package courier
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // WithLogger sets the Logger to use for the client.
 func WithLogger(l Logger) ClientOption { return optionFunc(func(o *clientOptions) { o.logger = l }) }
 
 // Logger is the interface that wraps the Info and Error methods.
 type Logger interface {
-	Info(ctx context.Context, msg string, attrs map[string]any)
 	Error(ctx context.Context, err error, attrs map[string]any)
+	Warn(ctx context.Context, msg string, attrs map[string]any)
+	Info(ctx context.Context, msg string, attrs map[string]any)
+	Debug(ctx context.Context, msg string, attrs map[string]any)
 }
 
 var defaultLogger Logger = noOpLogger{}
 
 type noOpLogger struct{}
 
-func (noOpLogger) Info(context.Context, string, map[string]any) {}
-func (noOpLogger) Error(context.Context, error, map[string]any) {}
+func (noOpLogger) Error(context.Context, error, map[string]any)  {}
+func (noOpLogger) Warn(context.Context, string, map[string]any)  {}
+func (noOpLogger) Info(context.Context, string, map[string]any)  {}
+func (noOpLogger) Debug(context.Context, string, map[string]any) {}
+
+type logLevel int
+
+const (
+	debugLevel logLevel = iota
+	warnLevel
+	errorLevel
+)
+
+type pahoLogger struct {
+	logger Logger
+	level  logLevel
+}
+
+func (l *pahoLogger) Println(v ...interface{}) {
+	switch l.level {
+	case errorLevel:
+		l.logger.Error(context.Background(), fmt.Errorf(fmt.Sprintln(v...)), nil)
+	case warnLevel:
+		l.logger.Warn(context.Background(), fmt.Sprintln(v...), nil)
+	case debugLevel:
+		l.logger.Debug(context.Background(), fmt.Sprintln(v...), nil)
+	}
+}
+
+func (l *pahoLogger) Printf(format string, v ...interface{}) {
+	switch l.level {
+	case errorLevel:
+		l.logger.Error(context.Background(), fmt.Errorf(format, v...), nil)
+	case warnLevel:
+		l.logger.Warn(context.Background(), fmt.Sprintf(format, v...), nil)
+	case debugLevel:
+		l.logger.Debug(context.Background(), fmt.Sprintf(format, v...), nil)
+	}
+}

--- a/log.go
+++ b/log.go
@@ -3,10 +3,21 @@ package courier
 import (
 	"context"
 	"fmt"
+	"sync"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 )
 
+var pahoLogInit sync.Once
+
 // WithLogger sets the Logger to use for the client.
-func WithLogger(l Logger) ClientOption { return optionFunc(func(o *clientOptions) { o.logger = l }) }
+func WithLogger(l Logger) ClientOption {
+	pahoLogInit.Do(func() {
+		initPahoLogging(l)
+	})
+
+	return optionFunc(func(o *clientOptions) { o.logger = l })
+}
 
 // Logger is the interface that wraps the Info and Error methods.
 type Logger interface {
@@ -31,6 +42,7 @@ const (
 	debugLevel logLevel = iota
 	warnLevel
 	errorLevel
+	criticalLevel
 )
 
 type pahoLogger struct {
@@ -38,24 +50,29 @@ type pahoLogger struct {
 	level  logLevel
 }
 
-func (l *pahoLogger) Println(v ...interface{}) {
+func (l pahoLogger) log(msg string, err error) {
 	switch l.level {
-	case errorLevel:
-		l.logger.Error(context.Background(), fmt.Errorf(fmt.Sprintln(v...)), nil)
+	case errorLevel, criticalLevel:
+		l.logger.Error(context.Background(), err, nil)
 	case warnLevel:
-		l.logger.Warn(context.Background(), fmt.Sprintln(v...), nil)
+		l.logger.Warn(context.Background(), msg, nil)
 	case debugLevel:
-		l.logger.Debug(context.Background(), fmt.Sprintln(v...), nil)
+		l.logger.Debug(context.Background(), msg, nil)
 	}
 }
 
-func (l *pahoLogger) Printf(format string, v ...interface{}) {
-	switch l.level {
-	case errorLevel:
-		l.logger.Error(context.Background(), fmt.Errorf(format, v...), nil)
-	case warnLevel:
-		l.logger.Warn(context.Background(), fmt.Sprintf(format, v...), nil)
-	case debugLevel:
-		l.logger.Debug(context.Background(), fmt.Sprintf(format, v...), nil)
-	}
+func (l pahoLogger) Println(v ...interface{}) {
+	msg := fmt.Sprintln(v...)
+	l.log(msg, fmt.Errorf(msg))
+}
+
+func (l pahoLogger) Printf(format string, v ...interface{}) {
+	l.log(fmt.Sprintf(format, v...), fmt.Errorf(format, v...))
+}
+
+func initPahoLogging(l Logger) {
+	mqtt.DEBUG = pahoLogger{logger: l, level: debugLevel}
+	mqtt.WARN = pahoLogger{logger: l, level: warnLevel}
+	mqtt.ERROR = pahoLogger{logger: l, level: errorLevel}
+	mqtt.CRITICAL = pahoLogger{logger: l, level: criticalLevel}
 }

--- a/log_test.go
+++ b/log_test.go
@@ -56,6 +56,13 @@ func Test_pahoLogger_Println(t *testing.T) {
 		mockFunc func(l *mockLogger)
 	}{
 		{
+			name:  "CriticalLevel",
+			level: criticalLevel,
+			mockFunc: func(l *mockLogger) {
+				l.On("Error", mock.Anything, mock.Anything, mock.Anything).Return()
+			},
+		},
+		{
 			name:  "ErrorLevel",
 			level: errorLevel,
 			mockFunc: func(l *mockLogger) {
@@ -101,6 +108,17 @@ func Test_pahoLogger_Printf(t *testing.T) {
 		format   string
 		args     []interface{}
 	}{
+		{
+			name:  "CriticalLevel",
+			level: criticalLevel,
+			mockFunc: func(l *mockLogger) {
+				l.On("Error", mock.Anything, mock.MatchedBy(func(err error) bool {
+					return err.Error() == "test error"
+				}), mock.Anything).Return()
+			},
+			format: "test %s",
+			args:   []interface{}{"error"},
+		},
 		{
 			name:  "ErrorLevel",
 			level: errorLevel,

--- a/log_test.go
+++ b/log_test.go
@@ -27,6 +27,14 @@ func (m *mockLogger) Error(ctx context.Context, err error, attrs map[string]any)
 	m.Called(ctx, err, attrs)
 }
 
+func (m *mockLogger) Warn(ctx context.Context, msg string, attrs map[string]any) {
+	m.Called(ctx, msg, attrs)
+}
+
+func (m *mockLogger) Debug(ctx context.Context, msg string, attrs map[string]any) {
+	m.Called(ctx, msg, attrs)
+}
+
 func newMockLogger(t *testing.T) *mockLogger {
 	m := &mockLogger{}
 	m.Test(t)
@@ -37,4 +45,104 @@ func Test_noOpLogger(t *testing.T) {
 	l := noOpLogger{}
 	l.Info(context.Background(), "", nil)
 	l.Error(context.Background(), nil, nil)
+	l.Warn(context.Background(), "", nil)
+	l.Debug(context.Background(), "", nil)
+}
+
+func Test_pahoLogger_Println(t *testing.T) {
+	tests := []struct {
+		name     string
+		level    logLevel
+		mockFunc func(l *mockLogger)
+	}{
+		{
+			name:  "ErrorLevel",
+			level: errorLevel,
+			mockFunc: func(l *mockLogger) {
+				l.On("Error", mock.Anything, mock.Anything, mock.Anything).Return()
+			},
+		},
+		{
+			name:  "WarnLevel",
+			level: warnLevel,
+			mockFunc: func(l *mockLogger) {
+				l.On("Warn", mock.Anything, mock.Anything, mock.Anything).Return()
+			},
+		},
+		{
+			name:  "DebugLevel",
+			level: debugLevel,
+			mockFunc: func(l *mockLogger) {
+				l.On("Debug", mock.Anything, mock.Anything, mock.Anything).Return()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := newMockLogger(t)
+			pl := &pahoLogger{
+				logger: l,
+				level:  tt.level,
+			}
+
+			tt.mockFunc(l)
+			pl.Println("test")
+			l.AssertExpectations(t)
+		})
+	}
+}
+
+func Test_pahoLogger_Printf(t *testing.T) {
+	tests := []struct {
+		name     string
+		level    logLevel
+		mockFunc func(l *mockLogger)
+		format   string
+		args     []interface{}
+	}{
+		{
+			name:  "ErrorLevel",
+			level: errorLevel,
+			mockFunc: func(l *mockLogger) {
+				l.On("Error", mock.Anything, mock.MatchedBy(func(err error) bool {
+					return err.Error() == "test error"
+				}), mock.Anything).Return()
+			},
+			format: "test %s",
+			args:   []interface{}{"error"},
+		},
+		{
+			name:  "WarnLevel",
+			level: warnLevel,
+			mockFunc: func(l *mockLogger) {
+				l.On("Warn", mock.Anything, "test warn", mock.Anything).Return()
+			},
+			format: "test %s",
+			args:   []interface{}{"warn"},
+		},
+		{
+			name:  "DebugLevel",
+			level: debugLevel,
+			mockFunc: func(l *mockLogger) {
+				l.On("Debug", mock.Anything, "test debug", mock.Anything).Return()
+			},
+			format: "test %s",
+			args:   []interface{}{"debug"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := newMockLogger(t)
+			pl := &pahoLogger{
+				logger: l,
+				level:  tt.level,
+			}
+
+			tt.mockFunc(l)
+			pl.Printf(tt.format, tt.args...)
+			l.AssertExpectations(t)
+		})
+	}
 }

--- a/slog/log.go
+++ b/slog/log.go
@@ -27,6 +27,14 @@ func (sw *slogWrapper) Error(ctx context.Context, err error, attrs map[string]an
 	sw.log.LogAttrs(ctx, slog.LevelError, err.Error(), sw.mapAttrs(attrs)...)
 }
 
+func (sw *slogWrapper) Warn(ctx context.Context, msg string, attrs map[string]any) {
+	sw.log.LogAttrs(ctx, slog.LevelWarn, msg, sw.mapAttrs(attrs)...)
+}
+
+func (sw *slogWrapper) Debug(ctx context.Context, msg string, attrs map[string]any) {
+	sw.log.LogAttrs(ctx, slog.LevelDebug, msg, sw.mapAttrs(attrs)...)
+}
+
 func (sw *slogWrapper) mapAttrs(attrs map[string]any) []slog.Attr {
 	logAttrs := make([]slog.Attr, 0, len(attrs))
 

--- a/slog/log_test.go
+++ b/slog/log_test.go
@@ -27,13 +27,19 @@ func TestWithLogger(t *testing.T) {
 
 func TestWithLoggerWrite(t *testing.T) {
 	buf := &bytes.Buffer{}
-	h := slog.NewTextHandler(buf, &slog.HandlerOptions{})
+	h := slog.NewTextHandler(buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})
 	logger := New(h)
 
 	logger.Info(context.TODO(), "test", map[string]any{"key": "value"})
 	logger.Error(context.TODO(), courier.ErrClientNotInitialized, map[string]any{"key": "value"})
+	logger.Warn(context.TODO(), "test", map[string]any{"key": "value"})
+	logger.Debug(context.TODO(), "test", map[string]any{"key": "value"})
 
 	out := buf.String()
 	assert.Contains(t, out, "level=INFO msg=test key=value")
 	assert.Contains(t, out, "level=ERROR msg=\"courier: client not initialized\" key=value")
+	assert.Contains(t, out, "level=WARN msg=test key=value")
+	assert.Contains(t, out, "level=DEBUG msg=test key=value")
 }


### PR DESCRIPTION
Paho logging is not enabled even if logger is initialised. This PR enables paho logging using the existing logger passed during courier-go client initialization.