### PR TITLE
feat: add parse log level func for paho

### DIFF
--- a/docs/docs/sdk/SDK.md
+++ b/docs/docs/sdk/SDK.md
@@ -70,6 +70,7 @@ Package courier contains the client that can be used to interact with the courie
 - [type EncoderFunc](#EncoderFunc)
 - [type KeepAlive](#KeepAlive)
 - [type LogLevel](#LogLevel)
+  - [func ParseLogLevel\(level string\) LogLevel](#ParseLogLevel)
 - [type Logger](#Logger)
 - [type MQTTClientInfo](#MQTTClientInfo)
 - [type Message](#Message)
@@ -771,6 +772,15 @@ const (
     LogLevelError
 )
 ```
+
+<a name="ParseLogLevel"></a>
+### func [ParseLogLevel](https://github.com/gojek/courier-go/blob/main/log.go#L60)
+
+```go
+func ParseLogLevel(level string) LogLevel
+```
+
+ParseLogLevel parses a string and returns the corresponding LogLevel. If the input is unrecognised, LogLevelDefault is returned.
 
 <a name="Logger"></a>
 ## type [Logger](https://github.com/gojek/courier-go/blob/main/log.go#L20-L23)

--- a/log.go
+++ b/log.go
@@ -54,3 +54,20 @@ func (l LogLevel) toPahoLogLevel() mqtt.LogLevel {
 		return mqtt.LogLevelDefault
 	}
 }
+
+// ParseLogLevel parses a string and returns the corresponding LogLevel.
+// If the input is unrecognised, LogLevelDefault is returned.
+func ParseLogLevel(level string) LogLevel {
+	switch level {
+	case "none":
+		return LogLevelDefault
+	case "debug":
+		return LogLevelDebug
+	case "warn":
+		return LogLevelWarn
+	case "error":
+		return LogLevelError
+	default:
+		return LogLevelDefault
+	}
+}

--- a/log_test.go
+++ b/log_test.go
@@ -56,3 +56,21 @@ func TestWithPahoLogLevel(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, LogLevelError.toPahoLogLevel(), c.options.pahoLogLevel)
 }
+
+func TestParseLogLevel(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected LogLevel
+	}{
+		{"", LogLevelDefault},
+		{"debug", LogLevelDebug},
+		{"warn", LogLevelWarn},
+		{"error", LogLevelError},
+		{"invalid", LogLevelDefault},
+	}
+
+	for _, test := range tests {
+		result := ParseLogLevel(test.input)
+		assert.Equal(t, test.expected, result)
+	}
+}


### PR DESCRIPTION
Add ParseLogLevel func, return corresponding level or level default (silent) if not found