### PR TITLE
fix: otel courier.client.connected metric on multiple courier instance

### DIFF
--- a/client_stop.go
+++ b/client_stop.go
@@ -1,0 +1,17 @@
+package courier
+
+// UseStopMiddleware allows setting a Stopper middleware to intercept Stop calls.
+func (c *Client) UseStopMiddleware(mwf StopMiddlewareFunc) {
+	c.stopMiddleware = mwf
+	if mwf != nil {
+		c.stopHandler = mwf.Middleware(stopHandlerFunc(c))
+	} else {
+		c.stopHandler = stopHandlerFunc(c)
+	}
+}
+
+func stopHandlerFunc(c *Client) Stopper {
+	return StopHandlerFunc(func() error {
+		return c.stop()
+	})
+}

--- a/client_stop_test.go
+++ b/client_stop_test.go
@@ -1,0 +1,73 @@
+package courier
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStopMiddleware(t *testing.T) {
+	c, err := NewClient(defOpts...)
+	require.NoError(t, err)
+
+	var middlewareCalled bool
+	var mu sync.Mutex
+
+	middleware := func(next Stopper) Stopper {
+		return StopHandlerFunc(func() error {
+			mu.Lock()
+			middlewareCalled = true
+			mu.Unlock()
+			return next.Stop()
+		})
+	}
+
+	c.UseStopMiddleware(middleware)
+
+	assert.NotNil(t, c.stopMiddleware)
+	assert.NotNil(t, c.stopHandler)
+
+	c.Stop()
+
+	mu.Lock()
+	assert.True(t, middlewareCalled, "Middleware should have been called")
+	mu.Unlock()
+}
+
+func TestStopHandlerFunc(t *testing.T) {
+	called := false
+	expectedError := errors.New("test error")
+
+	handler := StopHandlerFunc(func() error {
+		called = true
+		return expectedError
+	})
+
+	err := handler.Stop()
+	assert.True(t, called, "Function should have been called")
+	assert.Equal(t, expectedError, err, "Should return expected error")
+}
+
+func TestStopMiddlewareFunc(t *testing.T) {
+	nextCalled := false
+	nextHandler := StopHandlerFunc(func() error {
+		nextCalled = true
+		return nil
+	})
+
+	middlewareCalled := false
+	middleware := StopMiddlewareFunc(func(next Stopper) Stopper {
+		middlewareCalled = true
+		return next
+	})
+
+	wrappedHandler := middleware.Middleware(nextHandler)
+	assert.True(t, middlewareCalled, "Middleware function should have been called")
+
+	err := wrappedHandler.Stop()
+	assert.NoError(t, err)
+	assert.True(t, nextCalled, "Next handler should have been called")
+}

--- a/docs/docs/sdk/otelcourier.md
+++ b/docs/docs/sdk/otelcourier.md
@@ -18,9 +18,12 @@ Package otelcourier instruments the github.com/gojek/courier\-go package.
   - [func New\(service string, opts ...Option\) \*OTel](#New)
   - [func \(t \*OTel\) ApplyMiddlewares\(c UseMiddleware\)](#OTel.ApplyMiddlewares)
   - [func \(t \*OTel\) PublisherMiddleware\(next courier.Publisher\) courier.Publisher](#OTel.PublisherMiddleware)
+  - [func \(t \*OTel\) Stop\(\) error](#OTel.Stop)
+  - [func \(t \*OTel\) StopMiddleware\(next courier.Stopper\) courier.Stopper](#OTel.StopMiddleware)
   - [func \(t \*OTel\) SubscriberMiddleware\(next courier.Subscriber\) courier.Subscriber](#OTel.SubscriberMiddleware)
   - [func \(t \*OTel\) UnsubscriberMiddleware\(next courier.Unsubscriber\) courier.Unsubscriber](#OTel.UnsubscriberMiddleware)
 - [type Option](#Option)
+  - [func WithAttributes\(attrs ...attribute.KeyValue\) Option](#WithAttributes)
   - [func WithInfoHandlerFrom\(c interface\{ InfoHandler\(\) http.Handler \}\) Option](#WithInfoHandlerFrom)
   - [func WithMeterProvider\(provider metric.MeterProvider\) Option](#WithMeterProvider)
   - [func WithTextMapCarrierExtractFunc\(fn func\(context.Context\) propagation.TextMapCarrier\) Option](#WithTextMapCarrierExtractFunc)
@@ -76,7 +79,7 @@ var DisableUnsubscriberTracing = &disableTracePathOpt{traceUnsubscriber}
 ```
 
 <a name="DefaultTopicAttributeTransformer"></a>
-## func [DefaultTopicAttributeTransformer](https://github.com/gojek/courier-go/blob/main/otelcourier/options.go#L63)
+## func [DefaultTopicAttributeTransformer](https://github.com/gojek/courier-go/blob/main/otelcourier/options.go#L69)
 
 ```go
 func DefaultTopicAttributeTransformer(_ context.Context, topic string) string
@@ -85,7 +88,7 @@ func DefaultTopicAttributeTransformer(_ context.Context, topic string) string
 DefaultTopicAttributeTransformer is the default transformer for topic attribute.
 
 <a name="BucketBoundaries"></a>
-## type [BucketBoundaries](https://github.com/gojek/courier-go/blob/main/otelcourier/options.go#L66-L68)
+## type [BucketBoundaries](https://github.com/gojek/courier-go/blob/main/otelcourier/options.go#L72-L74)
 
 BucketBoundaries helps override default histogram bucket boundaries for metrics.
 
@@ -96,7 +99,7 @@ type BucketBoundaries struct {
 ```
 
 <a name="OTel"></a>
-## type [OTel](https://github.com/gojek/courier-go/blob/main/otelcourier/otel.go#L29-L41)
+## type [OTel](https://github.com/gojek/courier-go/blob/main/otelcourier/otel.go#L31-L45)
 
 OTel implements tracing & metric abilities using OpenTelemetry SDK.
 
@@ -107,7 +110,7 @@ type OTel struct {
 ```
 
 <a name="New"></a>
-### func [New](https://github.com/gojek/courier-go/blob/main/otelcourier/otel.go#L44)
+### func [New](https://github.com/gojek/courier-go/blob/main/otelcourier/otel.go#L48)
 
 ```go
 func New(service string, opts ...Option) *OTel
@@ -179,7 +182,7 @@ c.Stop()
 </details>
 
 <a name="OTel.ApplyMiddlewares"></a>
-### func \(\*OTel\) [ApplyMiddlewares](https://github.com/gojek/courier-go/blob/main/otelcourier/otel.go#L81)
+### func \(\*OTel\) [ApplyMiddlewares](https://github.com/gojek/courier-go/blob/main/otelcourier/otel.go#L86)
 
 ```go
 func (t *OTel) ApplyMiddlewares(c UseMiddleware)
@@ -196,6 +199,24 @@ func (t *OTel) PublisherMiddleware(next courier.Publisher) courier.Publisher
 
 PublisherMiddleware is a courier.PublisherMiddlewareFunc for tracing publish calls.
 
+<a name="OTel.Stop"></a>
+### func \(\*OTel\) [Stop](https://github.com/gojek/courier-go/blob/main/otelcourier/stop.go#L6)
+
+```go
+func (t *OTel) Stop() error
+```
+
+Stop implements the courier.Stopper interface to unregister any handlers or clean up resources.
+
+<a name="OTel.StopMiddleware"></a>
+### func \(\*OTel\) [StopMiddleware](https://github.com/gojek/courier-go/blob/main/otelcourier/stop.go#L19)
+
+```go
+func (t *OTel) StopMiddleware(next courier.Stopper) courier.Stopper
+```
+
+StopMiddleware returns a Stopper middleware that ensures OTel async metric is unregistered when the client stops.
+
 <a name="OTel.SubscriberMiddleware"></a>
 ### func \(\*OTel\) [SubscriberMiddleware](https://github.com/gojek/courier-go/blob/main/otelcourier/subscribe.go#L43)
 
@@ -206,7 +227,7 @@ func (t *OTel) SubscriberMiddleware(next courier.Subscriber) courier.Subscriber
 SubscriberMiddleware is a courier.SubscriberMiddlewareFunc for tracing subscribe calls.
 
 <a name="OTel.UnsubscriberMiddleware"></a>
-### func \(\*OTel\) [UnsubscriberMiddleware](https://github.com/gojek/courier-go/blob/main/otelcourier/unsubscribe.go#L21)
+### func \(\*OTel\) [UnsubscriberMiddleware](https://github.com/gojek/courier-go/blob/main/otelcourier/unsubscribe.go#L22)
 
 ```go
 func (t *OTel) UnsubscriberMiddleware(next courier.Unsubscriber) courier.Unsubscriber
@@ -215,7 +236,7 @@ func (t *OTel) UnsubscriberMiddleware(next courier.Unsubscriber) courier.Unsubsc
 UnsubscriberMiddleware is a courier.UnsubscriberMiddlewareFunc for tracing unsubscribe calls.
 
 <a name="Option"></a>
-## type [Option](https://github.com/gojek/courier-go/blob/main/otelcourier/options.go#L14)
+## type [Option](https://github.com/gojek/courier-go/blob/main/otelcourier/options.go#L15)
 
 Option helps configure trace options.
 
@@ -225,8 +246,17 @@ type Option interface {
 }
 ```
 
+<a name="WithAttributes"></a>
+### func [WithAttributes](https://github.com/gojek/courier-go/blob/main/otelcourier/options.go#L52)
+
+```go
+func WithAttributes(attrs ...attribute.KeyValue) Option
+```
+
+WithAttributes adds custom attributes to all spans and metrics created.
+
 <a name="WithInfoHandlerFrom"></a>
-### func [WithInfoHandlerFrom](https://github.com/gojek/courier-go/blob/main/otelcourier/options.go#L46)
+### func [WithInfoHandlerFrom](https://github.com/gojek/courier-go/blob/main/otelcourier/options.go#L47)
 
 ```go
 func WithInfoHandlerFrom(c interface{ InfoHandler() http.Handler }) Option
@@ -235,7 +265,7 @@ func WithInfoHandlerFrom(c interface{ InfoHandler() http.Handler }) Option
 WithInfoHandlerFrom is used to specify the handler which should be used to extract client information from the courier.Client instance.
 
 <a name="WithMeterProvider"></a>
-### func [WithMeterProvider](https://github.com/gojek/courier-go/blob/main/otelcourier/options.go#L28)
+### func [WithMeterProvider](https://github.com/gojek/courier-go/blob/main/otelcourier/options.go#L29)
 
 ```go
 func WithMeterProvider(provider metric.MeterProvider) Option
@@ -244,7 +274,7 @@ func WithMeterProvider(provider metric.MeterProvider) Option
 WithMeterProvider specifies a meter provider to use for creating a meter. If none is specified, the global provider is used.
 
 <a name="WithTextMapCarrierExtractFunc"></a>
-### func [WithTextMapCarrierExtractFunc](https://github.com/gojek/courier-go/blob/main/otelcourier/options.go#L40)
+### func [WithTextMapCarrierExtractFunc](https://github.com/gojek/courier-go/blob/main/otelcourier/options.go#L41)
 
 ```go
 func WithTextMapCarrierExtractFunc(fn func(context.Context) propagation.TextMapCarrier) Option
@@ -253,7 +283,7 @@ func WithTextMapCarrierExtractFunc(fn func(context.Context) propagation.TextMapC
 WithTextMapCarrierExtractFunc is used to specify the function which should be used to extract propagation.TextMapCarrier from the ongoing context.Context.
 
 <a name="WithTextMapPropagator"></a>
-### func [WithTextMapPropagator](https://github.com/gojek/courier-go/blob/main/otelcourier/options.go#L34)
+### func [WithTextMapPropagator](https://github.com/gojek/courier-go/blob/main/otelcourier/options.go#L35)
 
 ```go
 func WithTextMapPropagator(propagator propagation.TextMapPropagator) Option
@@ -262,7 +292,7 @@ func WithTextMapPropagator(propagator propagation.TextMapPropagator) Option
 WithTextMapPropagator specifies the propagator to use for extracting/injecting key\-value texts. If none is specified, the global provider is used.
 
 <a name="WithTracerProvider"></a>
-### func [WithTracerProvider](https://github.com/gojek/courier-go/blob/main/otelcourier/options.go#L22)
+### func [WithTracerProvider](https://github.com/gojek/courier-go/blob/main/otelcourier/options.go#L23)
 
 ```go
 func WithTracerProvider(provider oteltrace.TracerProvider) Option
@@ -271,7 +301,7 @@ func WithTracerProvider(provider oteltrace.TracerProvider) Option
 WithTracerProvider specifies a tracer provider to use for creating a tracer. If none is specified, the global provider is used.
 
 <a name="TopicAttributeTransformer"></a>
-## type [TopicAttributeTransformer](https://github.com/gojek/courier-go/blob/main/otelcourier/options.go#L18)
+## type [TopicAttributeTransformer](https://github.com/gojek/courier-go/blob/main/otelcourier/options.go#L19)
 
 TopicAttributeTransformer helps transform topic before making an attribute for it. It is used in metric recording only. Traces use the original topic.
 
@@ -280,7 +310,7 @@ type TopicAttributeTransformer func(context.Context, string) string
 ```
 
 <a name="UseMiddleware"></a>
-## type [UseMiddleware](https://github.com/gojek/courier-go/blob/main/otelcourier/otel.go#L22-L26)
+## type [UseMiddleware](https://github.com/gojek/courier-go/blob/main/otelcourier/otel.go#L23-L28)
 
 UseMiddleware is an interface that defines the methods to apply middlewares to a courier.Client or similar instance.
 
@@ -289,6 +319,7 @@ type UseMiddleware interface {
     UsePublisherMiddleware(mwf ...courier.PublisherMiddlewareFunc)
     UseSubscriberMiddleware(mwf ...courier.SubscriberMiddlewareFunc)
     UseUnsubscriberMiddleware(mwf ...courier.UnsubscriberMiddlewareFunc)
+    UseStopMiddleware(mwf courier.StopMiddlewareFunc)
 }
 ```
 

--- a/otelcourier/info_handler.go
+++ b/otelcourier/info_handler.go
@@ -18,10 +18,13 @@ type infoResponse struct {
 	Clients []courier.MQTTClientInfo `json:"clients,omitempty"`
 }
 
-func (e infoHandler) callback(attrs ...attribute.KeyValue) metric.Int64Callback {
+func (e infoHandler) callback(
+	observable metric.Int64ObservableUpDownCounter,
+	attrs ...attribute.KeyValue,
+) metric.Callback {
 	hf := http.HandlerFunc(e)
 
-	return func(ctx context.Context, observer metric.Int64Observer) error {
+	return func(ctx context.Context, observer metric.Observer) error {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
 		if err != nil {
 			return err
@@ -37,7 +40,8 @@ func (e infoHandler) callback(attrs ...attribute.KeyValue) metric.Int64Callback 
 		}
 
 		for _, cl := range ir.Clients {
-			observer.Observe(
+			observer.ObserveInt64(
+				observable,
 				boolInt64(cl.Connected),
 				metric.WithAttributes(append(attrs, MQTTClientID.String(cl.ClientID))...),
 			)

--- a/otelcourier/options.go
+++ b/otelcourier/options.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -45,6 +46,11 @@ func WithTextMapCarrierExtractFunc(fn func(context.Context) propagation.TextMapC
 // extract client information from the courier.Client instance.
 func WithInfoHandlerFrom(c interface{ InfoHandler() http.Handler }) Option {
 	return optFn(func(opts *options) { opts.infoHandler = c.InfoHandler() })
+}
+
+// WithAttributes adds custom attributes to all spans and metrics created.
+func WithAttributes(attrs ...attribute.KeyValue) Option {
+	return optFn(func(opts *options) { opts.attributes = attrs })
 }
 
 // DisableCallbackTracing disables implicit tracing on subscription callbacks.
@@ -100,6 +106,7 @@ type options struct {
 	topicTransformer        TopicAttributeTransformer
 	infoHandler             http.Handler
 	histogramBoundaries     map[tracePath][]float64
+	attributes              []attribute.KeyValue
 }
 
 type tracePath uint

--- a/otelcourier/options_test.go
+++ b/otelcourier/options_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
 )
 
@@ -160,5 +161,29 @@ func TestOption(t *testing.T) {
 		assert.Equal(t, []float64{4, 5, 6}, o.histogramBoundaries[traceSubscriber])
 		assert.Equal(t, []float64{7, 8, 9}, o.histogramBoundaries[traceUnsubscriber])
 		assert.Equal(t, []float64{10, 11, 12}, o.histogramBoundaries[traceCallback])
+	})
+
+	t.Run("WithAttributes", func(t *testing.T) {
+		opt := WithAttributes(
+			attribute.String("key", "value"),
+		)
+
+		opts := defaultOptions()
+		opt.apply(opts)
+
+		expected := []attribute.KeyValue{
+			attribute.String("key", "value"),
+		}
+
+		assert.Equal(t, expected, opts.attributes)
+	})
+
+	t.Run("WithAttributesEmpty", func(t *testing.T) {
+		opt := WithAttributes()
+
+		opts := defaultOptions()
+		opt.apply(opts)
+
+		assert.Empty(t, opts.attributes)
 	})
 }

--- a/otelcourier/publish.go
+++ b/otelcourier/publish.go
@@ -30,6 +30,9 @@ func (t *OTel) PublisherMiddleware(next courier.Publisher) courier.Publisher {
 		attrs := append([]attribute.KeyValue{
 			semconv.ServiceNameKey.String(t.service),
 		}, mapAttributes(opts)...)
+
+		attrs = append(attrs, t.attributes...)
+
 		metricAttrs := metric.WithAttributes(append(attrs, MQTTTopic.String(t.topicTransformer(ctx, topic)))...)
 
 		defer func(ctx context.Context, now time.Time, attrs metric.MeasurementOption) {

--- a/otelcourier/stop.go
+++ b/otelcourier/stop.go
@@ -1,0 +1,31 @@
+package otelcourier
+
+import "github.com/gojek/courier-go"
+
+// Stop implements the courier.Stopper interface to unregister any handlers or clean up resources.
+func (t *OTel) Stop() error {
+	if t.infoHandlerRegistration != nil {
+		if err := t.infoHandlerRegistration.Unregister(); err != nil {
+			return err
+		}
+
+		t.infoHandlerRegistration = nil
+	}
+
+	return nil
+}
+
+// StopMiddleware returns a Stopper middleware that ensures OTel async metric is unregistered when the client stops.
+func (t *OTel) StopMiddleware(next courier.Stopper) courier.Stopper {
+	return courier.StopHandlerFunc(func() error {
+		err := next.Stop()
+
+		if cleanupErr := t.Stop(); cleanupErr != nil {
+			if err == nil {
+				return cleanupErr
+			}
+		}
+
+		return err
+	})
+}

--- a/stopper.go
+++ b/stopper.go
@@ -1,0 +1,26 @@
+package courier
+
+// Stopper defines behaviour of an MQTT client stop.
+type Stopper interface {
+	Stop() error
+}
+
+// StopHandlerFunc defines signature of a Stop function.
+type StopHandlerFunc func() error
+
+// Stop implements Stopper interface on StopHandlerFunc.
+func (f StopHandlerFunc) Stop() error {
+	return f()
+}
+
+type stopMiddleware interface {
+	Middleware(stopper Stopper) Stopper
+}
+
+// StopMiddlewareFunc functions are closures that intercept Stopper.Stop calls.
+type StopMiddlewareFunc func(Stopper) Stopper
+
+// Middleware allows StopMiddlewareFunc to implement the stopMiddleware interface.
+func (smw StopMiddlewareFunc) Middleware(stopper Stopper) Stopper {
+	return smw(stopper)
+}


### PR DESCRIPTION
Fixes #54 