### PR TITLE
refactor: Migrate `golangci-lint` configuration to version 2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,74 +1,73 @@
+version: "2"
+run:
+  modules-download-mode: readonly
 linters:
-  disable-all: true
+  default: none
   enable:
-    - errcheck
-    - staticcheck
-    - unused
-    - gosimple
-    - ineffassign
-    - stylecheck
-    - typecheck
-    - unconvert
     - bodyclose
     - dupl
+    - errcheck
+    - funlen
     - goconst
     - gocyclo
-    - gofmt
+    - ineffassign
     - lll
     - misspell
     - nakedret
-    - funlen
     - nestif
     - nlreturn
     - prealloc
     - rowserrcheck
+    - staticcheck
     - unconvert
     - unparam
+    - unused
     - whitespace
-    - wsl
-run:
-  skip-dirs:
-    - bin
-  skip-files:
-    - .*mock.*\.go$
-    - version.go
-    - example_test.go
-  modules-download-mode: readonly
-linters-settings:
-  govet:
-    check-shadowing: true
-    enable-all: true
-    disable:
-      - asmdecl
-      - assign
-  errcheck:
-    check-type-assertions: false
-  misspell:
-    locale: UK
-    ignore-words:
-      - initialized
-  funlen:
-    lines: 80
-    statements: 40
-
-issues:
-  exclude-use-default: false
-  exclude:
-    - declaration of "(err|ctx)" shadows declaration at
-  exclude-rules:
-    - text: "^SA1019: .* is deprecated:"
-      linters:
-        - staticcheck
-    - path: _test\.go
-      linters:
-        - dupl
-        - gosec
-        - wsl
-        - lll
-        - funlen
-        - nlreturn
-        - unused
-    - path: _test\.go
-      text: ^Error return value is not checked$
-      linters:
-        - errcheck
+  settings:
+    errcheck:
+      check-type-assertions: false
+    funlen:
+      lines: 80
+      statements: 40
+    govet:
+      disable:
+        - asmdecl
+        - assign
+      enable-all: true
+    misspell:
+      locale: UK
+      ignore-rules:
+        - initialized
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - staticcheck
+        text: '^SA1019: .* is deprecated:'
+      - linters:
+          - dupl
+          - funlen
+          - gosec
+          - lll
+          - nlreturn
+          - unused
+        path: _test\.go
+      - linters:
+          - errcheck
+        path: _test\.go
+        text: ^Error return value is not checked$
+      - path: (.+)\.go$
+        text: declaration of "(err|ctx)" shadows declaration at
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ fix-md-href:
 # ========= Helpers ===========
 
 golangci-lint:
-	$(call install-if-needed,GOLANGCI_LINT,github.com/golangci/golangci-lint/cmd/golangci-lint,v1.64.8)
+	$(call install-if-needed,GOLANGCI_LINT,github.com/golangci/golangci-lint/cmd/golangci-lint,v2.7.2)
 
 gci:
 	$(call install-if-needed,GCI_BIN,github.com/daixiang0/gci,v0.10.1)


### PR DESCRIPTION
# Overview

This PR aims to fixes #95 by migrating the `golangci-lint` configuration from `v1` to the latest major version `v2`.

## Proposed Solution

> The latest major version `v2` was released last year with numerous improvements, so it is suggested to migrate to the newer version. Here the [changelog](https://golangci-lint.run/docs/product/changelog/#v200) with complete set of improvements and features in the `v2`.

The migration is done using the builtin `migrate` command of `golangci-lint`.
```fish
golangci-lint migrate --skip-validation
```
and also updated the version of `golangci-lint` specified in the `Makefile` from `1.64.8` to `v2.7.2`(*which is used for testing locally*) as well.
```diff
-	$(call install-if-needed,GOLANGCI_LINT,github.com/golangci/golangci-lint/cmd/golangci-lint,v1.64.8)
+	$(call install-if-needed,GOLANGCI_LINT,github.com/golangci/golangci-lint/cmd/golangci-lint,v2.7.2)
```

## Result 

![lint-fix](https://github.com/user-attachments/assets/e897fccb-cb89-4698-a217-b34b5ba52d7f)

cc: @parassharm80 @kenkalang