### PR TITLE
fix: chainDecoder error upon decoding same message twice

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -37,27 +37,24 @@ func ChainDecoderFunc(decoders ...DecoderFunc) DecoderFunc {
 	return func(ctx context.Context, r io.Reader) Decoder {
 		buf := new(bytes.Buffer)
 		if _, err := buf.ReadFrom(r); err != nil {
-			return &chainDecoder{decoders: nil}
+			return &chainDecoder{}
 		}
 
-		decs := make([]Decoder, 0, len(decoders))
-		for _, fn := range decoders {
-			decs = append(decs, fn(ctx, bytes.NewReader(buf.Bytes())))
-		}
-
-		return &chainDecoder{decoders: decs}
+		return &chainDecoder{fns: decoders, ctx: ctx, data: buf.Bytes()}
 	}
 }
 
 type chainDecoder struct {
-	decoders []Decoder
+	fns  []DecoderFunc
+	ctx  context.Context
+	data []byte
 }
 
 func (f *chainDecoder) Decode(v interface{}) error {
 	var errs []error
 
-	for _, dec := range f.decoders {
-		if err := dec.Decode(v); err != nil {
+	for _, fn := range f.fns {
+		if err := fn(f.ctx, bytes.NewReader(f.data)).Decode(v); err != nil {
 			errs = append(errs, err)
 
 			continue

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -149,6 +149,30 @@ func TestChainDecoder_SecondSuccess(t *testing.T) {
 	}
 }
 
+func TestChainDecoder_DecodeCalledTwice(t *testing.T) {
+	ctx := context.Background()
+	reader := strings.NewReader(data)
+
+	chain := ChainDecoderFunc(DefaultDecoderFunc, base64JsonDecoder)
+	dec := chain(ctx, reader)
+
+	var first map[string]string
+	if err := dec.Decode(&first); err != nil {
+		t.Fatalf("=got: %v", err)
+	}
+	if first["key"] != "value" {
+		t.Errorf("got %q", first["key"])
+	}
+
+	var second map[string]string
+	if err := dec.Decode(&second); err != nil {
+		t.Fatalf("got: %v", err)
+	}
+	if second["key"] != "value" {
+		t.Errorf("got %q", second["key"])
+	}
+}
+
 func TestChainDecoder_AllFail(t *testing.T) {
 	ctx := context.Background()
 	reader := strings.NewReader(data)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -27,7 +27,10 @@ func Test_jsonDecoderSuite(t *testing.T) {
 	suite.Run(t, new(jsonDecoderSuite))
 }
 
-const data = `{"key":"value"}`
+const (
+	data          = `{"key":"value"}`
+	expectedValue = "value"
+)
 
 func (s *jsonDecoderSuite) TestDecode() {
 	type obj struct {
@@ -120,8 +123,8 @@ func TestChainDecoder_FirstSuccess(t *testing.T) {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	if result["key"] != "value" {
-		t.Errorf("expected value 'value', got %q", result["key"])
+	if result["key"] != expectedValue {
+		t.Errorf("expected value %q, got %q", expectedValue, result["key"])
 	}
 }
 
@@ -144,8 +147,8 @@ func TestChainDecoder_SecondSuccess(t *testing.T) {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	if result["key"] != "value" {
-		t.Errorf("expected value 'value', got %q", result["key"])
+	if result["key"] != expectedValue {
+		t.Errorf("expected value %q, got %q", expectedValue, result["key"])
 	}
 }
 
@@ -160,7 +163,7 @@ func TestChainDecoder_DecodeCalledTwice(t *testing.T) {
 	if err := dec.Decode(&first); err != nil {
 		t.Fatalf("=got: %v", err)
 	}
-	if first["key"] != "value" {
+	if first["key"] != expectedValue {
 		t.Errorf("got %q", first["key"])
 	}
 
@@ -168,7 +171,7 @@ func TestChainDecoder_DecodeCalledTwice(t *testing.T) {
 	if err := dec.Decode(&second); err != nil {
 		t.Fatalf("got: %v", err)
 	}
-	if second["key"] != "value" {
+	if second["key"] != expectedValue {
 		t.Errorf("got %q", second["key"])
 	}
 }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -161,7 +161,7 @@ func TestChainDecoder_DecodeCalledTwice(t *testing.T) {
 
 	var first map[string]string
 	if err := dec.Decode(&first); err != nil {
-		t.Fatalf("=got: %v", err)
+		t.Fatalf("got: %v", err)
 	}
 	if first["key"] != expectedValue {
 		t.Errorf("got %q", first["key"])


### PR DESCRIPTION
Fresh decoder will only be created upon new messages previously, so when Decode called twice on the same message, it has the same chained decoder that has been used by previous Decode call